### PR TITLE
Enhancement to get detailed summary of bad messages

### DIFF
--- a/src/main/java/uk/gov/ons/census/exceptionmanager/config/AppConfig.java
+++ b/src/main/java/uk/gov/ons/census/exceptionmanager/config/AppConfig.java
@@ -3,11 +3,19 @@ package uk.gov.ons.census.exceptionmanager.config;
 import java.util.TimeZone;
 import javax.annotation.PostConstruct;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
-public class AppConfig {
+public class AppConfig implements WebMvcConfigurer {
+
   @PostConstruct
   public void init() {
     TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+  }
+
+  @Override
+  public void addCorsMappings(CorsRegistry registry) {
+    registry.addMapping("/**");
   }
 }

--- a/src/main/java/uk/gov/ons/census/exceptionmanager/model/BadMessageSummary.java
+++ b/src/main/java/uk/gov/ons/census/exceptionmanager/model/BadMessageSummary.java
@@ -1,0 +1,16 @@
+package uk.gov.ons.census.exceptionmanager.model;
+
+import java.time.Instant;
+import java.util.Set;
+import lombok.Data;
+
+@Data
+public class BadMessageSummary {
+  private String messageHash;
+  private Instant firstSeen;
+  private Instant lastSeen;
+  private int seenCount;
+  private Set<String> affectedServices;
+  private Set<String> affectedQueues;
+  private boolean quarantined;
+}


### PR DESCRIPTION
# Motivation and Context
To enable the CLI (or maybe a UI at some future date) to be able to display more useful information without having to drill-down into each individual bad message, we need a summary of the problems with more detail.

# What has changed
Added API endpoint to get a summary including multiple bits of data which allow the current issues to be sorted to the top of the list.

# How to test?
Create some problems with dodgy messages. Curl to the `/badmessages/summary` endpoint. View the output.

# Links
Nope