### PR TITLE
Making dockerfile to use non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 FROM openjdk:11-slim
 
+CMD ["/usr/local/openjdk-11/bin/java", "-jar", "/opt/census-rm-exception-manager.jar"]
+
+RUN apt-get update && \
+apt-get -yq install curl && \
+apt-get -yq clean && \
+rm -rf /var/lib/apt/lists/*
+
 ARG JAR_FILE=census-rm-exception-manager*.jar
 COPY target/$JAR_FILE /opt/census-rm-exception-manager.jar
-
-RUN apt-get update
-RUN apt-get -yq install curl
-RUN apt-get -yq clean
-
-CMD exec /usr/local/openjdk-11/bin/java $JAVA_OPTS -jar /opt/census-rm-exception-manager.jar


### PR DESCRIPTION
# Motivation and Context
Running docker containers in root is a security concern so there should be a user that's created that the container can use instead. 

# What has changed
- Added a non-root user
- Updated dockerfile layout
- Use `JAVA_TOOL_OPTIONS` in compose files instead of `JAVA_OPTS`
# How to test?
- Run mvn clean install
- Run in docker dev environment with other prs
- Run in kubernetes environment with other prs

# Links
[Trello](https://trello.com/c/dUT7y0TW)