### PR TITLE
Making the exception manager non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,10 @@ apt-get -yq install curl && \
 apt-get -yq clean && \
 rm -rf /var/lib/apt/lists/*
 
+RUN groupadd --gid 999 exceptionmanager && \
+    useradd --create-home --system --uid 999 --gid exceptionmanager exceptionmanager
+USER exceptionmanager
+
+
 ARG JAR_FILE=census-rm-exception-manager*.jar
 COPY target/$JAR_FILE /opt/census-rm-exception-manager.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,5 @@ RUN groupadd --gid 999 exceptionmanager && \
     useradd --create-home --system --uid 999 --gid exceptionmanager exceptionmanager
 USER exceptionmanager
 
-
 ARG JAR_FILE=census-rm-exception-manager*.jar
 COPY target/$JAR_FILE /opt/census-rm-exception-manager.jar


### PR DESCRIPTION
# Motivation and Context
Somehow I didn't push changes to make the exception manager non-root so here it is.
# What has changed
- Exception manager non-root

# How to test?
- Run with Docker dev and kubernetes to make sure acceptance tests work