### PR TITLE
Bump Spring version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
   <parent>
     <artifactId>spring-boot-starter-parent</artifactId>
     <groupId>org.springframework.boot</groupId>
-    <version>2.1.3.RELEASE</version>
+    <version>2.2.7.RELEASE</version>
   </parent>
 
   <properties>


### PR DESCRIPTION
# Motivation and Context
We should keep Spring Boot up to date, because newer versions contain many security, stability and performance improvements, and it ensures that we never end up running an unsupported old version

# What has changed
Bumped Spring up to v2.2.7.

# How to test?
Should be zero regression.

# Links
Trello: https://trello.com/c/sNmbnD6B