### PR TITLE
Persist quarantined messages to DB

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,35 @@
         <groupId>org.apache.maven.plugins</groupId>
       </plugin>
       <plugin>
+        <groupId>com.dkanejs.maven.plugins</groupId>
+        <artifactId>docker-compose-maven-plugin</artifactId>
+        <version>2.4.0</version>
+        <executions>
+          <execution>
+            <id>up</id>
+            <phase>pre-integration-test</phase>
+            <goals>
+              <goal>up</goal>
+            </goals>
+            <configuration>
+              <composeFile>${project.basedir}/src/test/resources/docker-compose.yml</composeFile>
+              <detachedMode>true</detachedMode>
+            </configuration>
+          </execution>
+          <execution>
+            <id>down</id>
+            <phase>post-integration-test</phase>
+            <goals>
+              <goal>down</goal>
+            </goals>
+            <configuration>
+              <composeFile>${project.basedir}/src/test/resources/docker-compose.yml</composeFile>
+              <removeVolumes>true</removeVolumes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <artifactId>spring-boot-maven-plugin</artifactId>
         <configuration>
           <executable>true</executable>
@@ -104,6 +133,10 @@
       <groupId>org.springframework.boot</groupId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+    </dependency>
+    <dependency>
       <artifactId>spring-web</artifactId>
       <groupId>org.springframework</groupId>
     </dependency>
@@ -117,6 +150,15 @@
       <artifactId>logging</artifactId>
       <groupId>com.godaddy</groupId>
       <version>1.2.5</version>
+    </dependency>
+    <dependency>
+      <groupId>com.vladmihalcea</groupId>
+      <artifactId>hibernate-types-5</artifactId>
+      <version>2.4.3</version>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
     </dependency>
 
     <!--    Test Dependencies below this point -->

--- a/src/main/java/uk/gov/ons/census/exceptionmanager/endpoint/AdminEndpoint.java
+++ b/src/main/java/uk/gov/ons/census/exceptionmanager/endpoint/AdminEndpoint.java
@@ -13,9 +13,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
-import uk.gov.ons.census.exceptionmanager.model.BadMessageReport;
-import uk.gov.ons.census.exceptionmanager.model.BadMessageSummary;
-import uk.gov.ons.census.exceptionmanager.model.SkippedMessage;
+import uk.gov.ons.census.exceptionmanager.model.dto.BadMessageReport;
+import uk.gov.ons.census.exceptionmanager.model.dto.BadMessageSummary;
+import uk.gov.ons.census.exceptionmanager.model.dto.SkippedMessage;
 import uk.gov.ons.census.exceptionmanager.persistence.InMemoryDatabase;
 
 @RestController

--- a/src/main/java/uk/gov/ons/census/exceptionmanager/endpoint/ReportingEndpoint.java
+++ b/src/main/java/uk/gov/ons/census/exceptionmanager/endpoint/ReportingEndpoint.java
@@ -1,22 +1,31 @@
 package uk.gov.ons.census.exceptionmanager.endpoint;
 
+import java.util.UUID;
+import javax.transaction.Transactional;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
-import uk.gov.ons.census.exceptionmanager.model.ExceptionReport;
-import uk.gov.ons.census.exceptionmanager.model.Peek;
-import uk.gov.ons.census.exceptionmanager.model.Response;
-import uk.gov.ons.census.exceptionmanager.model.SkippedMessage;
+import uk.gov.ons.census.exceptionmanager.helper.JsonHelper;
+import uk.gov.ons.census.exceptionmanager.model.dto.ExceptionReport;
+import uk.gov.ons.census.exceptionmanager.model.dto.Peek;
+import uk.gov.ons.census.exceptionmanager.model.dto.Response;
+import uk.gov.ons.census.exceptionmanager.model.dto.SkippedMessage;
+import uk.gov.ons.census.exceptionmanager.model.entity.QuarantinedMessage;
+import uk.gov.ons.census.exceptionmanager.model.repository.QuarantinedMessageRepository;
 import uk.gov.ons.census.exceptionmanager.persistence.InMemoryDatabase;
 
 @RestController
-public final class ReportingEndpoint {
+public class ReportingEndpoint {
   private final InMemoryDatabase inMemoryDatabase;
+  private final QuarantinedMessageRepository quarantinedMessageRepository;
 
-  public ReportingEndpoint(InMemoryDatabase inMemoryDatabase) {
+  public ReportingEndpoint(
+      InMemoryDatabase inMemoryDatabase,
+      QuarantinedMessageRepository quarantinedMessageRepository) {
     this.inMemoryDatabase = inMemoryDatabase;
+    this.quarantinedMessageRepository = quarantinedMessageRepository;
   }
 
   @PostMapping(path = "/reportexception")
@@ -38,8 +47,25 @@ public final class ReportingEndpoint {
     inMemoryDatabase.storePeekMessageReply(peekReply);
   }
 
+  @Transactional
   @PostMapping(path = "/storeskippedmessage")
   public void storeSkippedMessage(@RequestBody SkippedMessage skippedMessage) {
     inMemoryDatabase.storeSkippedMessage(skippedMessage);
+    String errorReports =
+        JsonHelper.convertObjectToJson(
+            inMemoryDatabase.getBadMessageReports(skippedMessage.getMessageHash()));
+
+    QuarantinedMessage quarantinedMessage = new QuarantinedMessage();
+    quarantinedMessage.setId(UUID.randomUUID());
+    quarantinedMessage.setContentType(skippedMessage.getContentType());
+    quarantinedMessage.setHeaders(skippedMessage.getHeaders());
+    quarantinedMessage.setMessageHash(skippedMessage.getMessageHash());
+    quarantinedMessage.setMessagePayload(skippedMessage.getMessagePayload());
+    quarantinedMessage.setQueue(skippedMessage.getQueue());
+    quarantinedMessage.setRoutingKey(skippedMessage.getRoutingKey());
+    quarantinedMessage.setService(skippedMessage.getService());
+    quarantinedMessage.setErrorReports(errorReports);
+
+    quarantinedMessageRepository.save(quarantinedMessage);
   }
 }

--- a/src/main/java/uk/gov/ons/census/exceptionmanager/helper/JsonHelper.java
+++ b/src/main/java/uk/gov/ons/census/exceptionmanager/helper/JsonHelper.java
@@ -1,0 +1,25 @@
+package uk.gov.ons.census.exceptionmanager.helper;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+public class JsonHelper {
+  private static final ObjectMapper objectMapper;
+
+  static {
+    objectMapper =
+        new ObjectMapper()
+            .registerModule(new JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+  }
+
+  public static String convertObjectToJson(Object obj) {
+    try {
+      return objectMapper.writeValueAsString(obj);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("Failed converting Object To Json", e);
+    }
+  }
+}

--- a/src/main/java/uk/gov/ons/census/exceptionmanager/model/dto/BadMessageReport.java
+++ b/src/main/java/uk/gov/ons/census/exceptionmanager/model/dto/BadMessageReport.java
@@ -1,4 +1,4 @@
-package uk.gov.ons.census.exceptionmanager.model;
+package uk.gov.ons.census.exceptionmanager.model.dto;
 
 import lombok.Data;
 

--- a/src/main/java/uk/gov/ons/census/exceptionmanager/model/dto/BadMessageSummary.java
+++ b/src/main/java/uk/gov/ons/census/exceptionmanager/model/dto/BadMessageSummary.java
@@ -1,4 +1,4 @@
-package uk.gov.ons.census.exceptionmanager.model;
+package uk.gov.ons.census.exceptionmanager.model.dto;
 
 import java.time.Instant;
 import java.util.Set;

--- a/src/main/java/uk/gov/ons/census/exceptionmanager/model/dto/ExceptionReport.java
+++ b/src/main/java/uk/gov/ons/census/exceptionmanager/model/dto/ExceptionReport.java
@@ -1,4 +1,4 @@
-package uk.gov.ons.census.exceptionmanager.model;
+package uk.gov.ons.census.exceptionmanager.model.dto;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;

--- a/src/main/java/uk/gov/ons/census/exceptionmanager/model/dto/ExceptionStats.java
+++ b/src/main/java/uk/gov/ons/census/exceptionmanager/model/dto/ExceptionStats.java
@@ -1,4 +1,4 @@
-package uk.gov.ons.census.exceptionmanager.model;
+package uk.gov.ons.census.exceptionmanager.model.dto;
 
 import java.time.Instant;
 import java.util.concurrent.atomic.AtomicInteger;

--- a/src/main/java/uk/gov/ons/census/exceptionmanager/model/dto/Peek.java
+++ b/src/main/java/uk/gov/ons/census/exceptionmanager/model/dto/Peek.java
@@ -1,4 +1,4 @@
-package uk.gov.ons.census.exceptionmanager.model;
+package uk.gov.ons.census.exceptionmanager.model.dto;
 
 import lombok.Data;
 

--- a/src/main/java/uk/gov/ons/census/exceptionmanager/model/dto/Response.java
+++ b/src/main/java/uk/gov/ons/census/exceptionmanager/model/dto/Response.java
@@ -1,4 +1,4 @@
-package uk.gov.ons.census.exceptionmanager.model;
+package uk.gov.ons.census.exceptionmanager.model.dto;
 
 import lombok.Data;
 

--- a/src/main/java/uk/gov/ons/census/exceptionmanager/model/dto/SkippedMessage.java
+++ b/src/main/java/uk/gov/ons/census/exceptionmanager/model/dto/SkippedMessage.java
@@ -1,4 +1,4 @@
-package uk.gov.ons.census.exceptionmanager.model;
+package uk.gov.ons.census.exceptionmanager.model.dto;
 
 import java.time.Instant;
 import java.util.Map;

--- a/src/main/java/uk/gov/ons/census/exceptionmanager/model/entity/QuarantinedMessage.java
+++ b/src/main/java/uk/gov/ons/census/exceptionmanager/model/entity/QuarantinedMessage.java
@@ -1,0 +1,49 @@
+package uk.gov.ons.census.exceptionmanager.model.entity;
+
+import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
+import java.time.OffsetDateTime;
+import java.util.Map;
+import java.util.UUID;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Lob;
+import lombok.Data;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.TypeDef;
+import org.hibernate.annotations.TypeDefs;
+
+@Data
+@Entity
+@TypeDefs({@TypeDef(name = "jsonb", typeClass = JsonBinaryType.class)})
+public class QuarantinedMessage {
+  @Id private UUID id;
+
+  @Column(columnDefinition = "timestamp with time zone")
+  @CreationTimestamp
+  private OffsetDateTime skippedTimestamp;
+
+  @Column private String messageHash;
+
+  @Lob
+  @Type(type = "org.hibernate.type.BinaryType")
+  @Column
+  private byte[] messagePayload;
+
+  @Column private String service;
+
+  @Column private String queue;
+
+  @Column private String routingKey;
+
+  @Column private String contentType;
+
+  @Type(type = "jsonb")
+  @Column(columnDefinition = "jsonb")
+  private Map<String, String> headers;
+
+  @Type(type = "jsonb")
+  @Column(columnDefinition = "jsonb")
+  private String errorReports;
+}

--- a/src/main/java/uk/gov/ons/census/exceptionmanager/model/repository/QuarantinedMessageRepository.java
+++ b/src/main/java/uk/gov/ons/census/exceptionmanager/model/repository/QuarantinedMessageRepository.java
@@ -1,0 +1,7 @@
+package uk.gov.ons.census.exceptionmanager.model.repository;
+
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import uk.gov.ons.census.exceptionmanager.model.entity.QuarantinedMessage;
+
+public interface QuarantinedMessageRepository extends JpaRepository<QuarantinedMessage, UUID> {}

--- a/src/main/java/uk/gov/ons/census/exceptionmanager/persistence/InMemoryDatabase.java
+++ b/src/main/java/uk/gov/ons/census/exceptionmanager/persistence/InMemoryDatabase.java
@@ -9,11 +9,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.springframework.stereotype.Component;
-import uk.gov.ons.census.exceptionmanager.model.BadMessageReport;
-import uk.gov.ons.census.exceptionmanager.model.ExceptionReport;
-import uk.gov.ons.census.exceptionmanager.model.ExceptionStats;
-import uk.gov.ons.census.exceptionmanager.model.Peek;
-import uk.gov.ons.census.exceptionmanager.model.SkippedMessage;
+import uk.gov.ons.census.exceptionmanager.model.dto.BadMessageReport;
+import uk.gov.ons.census.exceptionmanager.model.dto.ExceptionReport;
+import uk.gov.ons.census.exceptionmanager.model.dto.ExceptionStats;
+import uk.gov.ons.census.exceptionmanager.model.dto.Peek;
+import uk.gov.ons.census.exceptionmanager.model.dto.SkippedMessage;
 
 @Component
 public class InMemoryDatabase {
@@ -74,7 +74,6 @@ public class InMemoryDatabase {
   }
 
   public synchronized void storeSkippedMessage(SkippedMessage skippedMessage) {
-    // TODO: Persist this to a Rabbit queue or a database so it can be replayed if necessary
     // Make damn certain this is thread safe so we don't lose anything
     List<SkippedMessage> skippedMessageList =
         skippedMessages.computeIfAbsent(skippedMessage.getMessageHash(), key -> new LinkedList<>());

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,27 @@ info:
     name: Bad Message Handler
     version: 1.0
 
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:6432/postgres
+    username: postgres
+    password: postgres
+    driverClassName: org.postgresql.Driver
+    initialization-mode: always
+    hikari:
+      maximumPoolSize: 50
+
+  jpa:
+    database-platform: org.hibernate.dialect.PostgreSQL94Dialect
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        default_schema: exceptionmanager
+        jdbc:
+          lob:
+            non_contextual_creation: true
+
 management:
   endpoints:
     enabled-by-default: true

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,1 @@
+CREATE SCHEMA IF NOT EXISTS exceptionmanager;

--- a/src/test/java/uk/gov/ons/census/exceptionmanager/endpoint/AdminEndpointTest.java
+++ b/src/test/java/uk/gov/ons/census/exceptionmanager/endpoint/AdminEndpointTest.java
@@ -13,11 +13,11 @@ import java.util.Map;
 import java.util.Set;
 import org.junit.Test;
 import org.springframework.http.ResponseEntity;
-import uk.gov.ons.census.exceptionmanager.model.BadMessageReport;
-import uk.gov.ons.census.exceptionmanager.model.BadMessageSummary;
-import uk.gov.ons.census.exceptionmanager.model.ExceptionReport;
-import uk.gov.ons.census.exceptionmanager.model.ExceptionStats;
-import uk.gov.ons.census.exceptionmanager.model.SkippedMessage;
+import uk.gov.ons.census.exceptionmanager.model.dto.BadMessageReport;
+import uk.gov.ons.census.exceptionmanager.model.dto.BadMessageSummary;
+import uk.gov.ons.census.exceptionmanager.model.dto.ExceptionReport;
+import uk.gov.ons.census.exceptionmanager.model.dto.ExceptionStats;
+import uk.gov.ons.census.exceptionmanager.model.dto.SkippedMessage;
 import uk.gov.ons.census.exceptionmanager.persistence.InMemoryDatabase;
 
 public class AdminEndpointTest {

--- a/src/test/java/uk/gov/ons/census/exceptionmanager/persistence/InMemoryDatabaseTest.java
+++ b/src/test/java/uk/gov/ons/census/exceptionmanager/persistence/InMemoryDatabaseTest.java
@@ -5,11 +5,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
-import uk.gov.ons.census.exceptionmanager.model.BadMessageReport;
-import uk.gov.ons.census.exceptionmanager.model.ExceptionReport;
-import uk.gov.ons.census.exceptionmanager.model.ExceptionStats;
-import uk.gov.ons.census.exceptionmanager.model.Peek;
-import uk.gov.ons.census.exceptionmanager.model.SkippedMessage;
+import uk.gov.ons.census.exceptionmanager.model.dto.BadMessageReport;
+import uk.gov.ons.census.exceptionmanager.model.dto.ExceptionReport;
+import uk.gov.ons.census.exceptionmanager.model.dto.ExceptionStats;
+import uk.gov.ons.census.exceptionmanager.model.dto.Peek;
+import uk.gov.ons.census.exceptionmanager.model.dto.SkippedMessage;
 
 public class InMemoryDatabaseTest {
   @Test

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,3 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:15432/postgres

--- a/src/test/resources/docker-compose.yml
+++ b/src/test/resources/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '2.1'
+services:
+  postgres:
+    container_name: postgres-exceptionmanager-it
+    image: sdcplatform/ras-rm-docker-postgres
+    command: ["-c", "shared_buffers=256MB", "-c", "max_connections=200"]
+    ports:
+      - "15432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5


### PR DESCRIPTION
# Motivation and Context
For speed of development during the rehearsal, we didn't make the Exception Manager persistent. We now need to have the service backed by a persistent data store instead of using a Rabbit queue to save the quarantined messages.

# What has changed
Added persistence.

# How to test?
Publish a bad message onto a Rabbit queue. Quarantine the bad message. Check the `exceptionmanager` database.

# Links
Trello: https://trello.com/c/sYuR2Vgw