### PR TITLE
Add rule-based auto quarantine

### DIFF
--- a/src/main/java/uk/gov/ons/census/exceptionmanager/endpoint/AdminEndpoint.java
+++ b/src/main/java/uk/gov/ons/census/exceptionmanager/endpoint/AdminEndpoint.java
@@ -7,12 +7,16 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+import uk.gov.ons.census.exceptionmanager.model.dto.AutoQuarantineRule;
 import uk.gov.ons.census.exceptionmanager.model.dto.BadMessageReport;
 import uk.gov.ons.census.exceptionmanager.model.dto.BadMessageSummary;
 import uk.gov.ons.census.exceptionmanager.model.dto.SkippedMessage;
@@ -68,7 +72,7 @@ public class AdminEndpoint {
       badMessageSummary.setSeenCount(seenCount);
       badMessageSummary.setAffectedServices(affectedServices);
       badMessageSummary.setAffectedQueues(affectedQueues);
-      badMessageSummary.setQuarantined(inMemoryDatabase.shouldWeSkipThisMessage(messageHash));
+      badMessageSummary.setQuarantined(inMemoryDatabase.isQuarantined(messageHash));
     }
 
     return ResponseEntity.status(HttpStatus.OK).body(badMessageSummaryList);
@@ -126,5 +130,11 @@ public class AdminEndpoint {
   @GetMapping(path = "/reset")
   public void reset() {
     inMemoryDatabase.reset();
+  }
+
+  @Transactional
+  @PostMapping(path = "/quarantinerule")
+  public void addQuarantineRule(@RequestBody AutoQuarantineRule autoQuarantineRule) {
+    inMemoryDatabase.addQuarantineRuleExpression(autoQuarantineRule.getExpression());
   }
 }

--- a/src/main/java/uk/gov/ons/census/exceptionmanager/endpoint/ReportingEndpoint.java
+++ b/src/main/java/uk/gov/ons/census/exceptionmanager/endpoint/ReportingEndpoint.java
@@ -33,7 +33,7 @@ public class ReportingEndpoint {
     Response result = new Response();
     String messageHash = exceptionReport.getMessageHash();
 
-    result.setSkipIt(inMemoryDatabase.shouldWeSkipThisMessage(messageHash));
+    result.setSkipIt(inMemoryDatabase.shouldWeSkipThisMessage(exceptionReport));
     result.setPeek(inMemoryDatabase.shouldWePeekThisMessage(messageHash));
     result.setLogIt(inMemoryDatabase.shouldWeLogThisMessage(exceptionReport));
 

--- a/src/main/java/uk/gov/ons/census/exceptionmanager/model/dto/AutoQuarantineRule.java
+++ b/src/main/java/uk/gov/ons/census/exceptionmanager/model/dto/AutoQuarantineRule.java
@@ -1,0 +1,8 @@
+package uk.gov.ons.census.exceptionmanager.model.dto;
+
+import lombok.Data;
+
+@Data
+public class AutoQuarantineRule {
+  private String expression;
+}

--- a/src/main/java/uk/gov/ons/census/exceptionmanager/model/entity/AutoQuarantineRule.java
+++ b/src/main/java/uk/gov/ons/census/exceptionmanager/model/entity/AutoQuarantineRule.java
@@ -1,0 +1,15 @@
+package uk.gov.ons.census.exceptionmanager.model.entity;
+
+import java.util.UUID;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import lombok.Data;
+
+@Data
+@Entity
+public class AutoQuarantineRule {
+  @Id private UUID id;
+
+  @Column private String expression;
+}

--- a/src/main/java/uk/gov/ons/census/exceptionmanager/model/repository/AutoQuarantineRuleRepository.java
+++ b/src/main/java/uk/gov/ons/census/exceptionmanager/model/repository/AutoQuarantineRuleRepository.java
@@ -1,0 +1,7 @@
+package uk.gov.ons.census.exceptionmanager.model.repository;
+
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import uk.gov.ons.census.exceptionmanager.model.entity.AutoQuarantineRule;
+
+public interface AutoQuarantineRuleRepository extends JpaRepository<AutoQuarantineRule, UUID> {}

--- a/src/main/java/uk/gov/ons/census/exceptionmanager/persistence/InMemoryDatabase.java
+++ b/src/main/java/uk/gov/ons/census/exceptionmanager/persistence/InMemoryDatabase.java
@@ -72,7 +72,6 @@ public class InMemoryDatabase {
   }
 
   public boolean shouldWeSkipThisMessage(ExceptionReport exceptionReport) {
-    boolean autoQuarantineMessage = false;
     EvaluationContext context = new StandardEvaluationContext(exceptionReport);
     for (Expression expression : autoQuarantineExpressions) {
       Boolean expressionResult = expression.getValue(context, Boolean.class);
@@ -80,12 +79,9 @@ public class InMemoryDatabase {
         log.with("exception_report", exceptionReport)
             .with("expression", expression.getExpressionString())
             .warn("Auto-quarantine message rule matched");
-        autoQuarantineMessage = true;
-        break;
+        return true;
       }
     }
-
-    if (autoQuarantineMessage) return true;
 
     return messagesToSkip.contains(exceptionReport.getMessageHash());
   }

--- a/src/test/java/uk/gov/ons/census/exceptionmanager/endpoint/AdminEndpointTest.java
+++ b/src/test/java/uk/gov/ons/census/exceptionmanager/endpoint/AdminEndpointTest.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.Set;
 import org.junit.Test;
 import org.springframework.http.ResponseEntity;
+import uk.gov.ons.census.exceptionmanager.model.dto.AutoQuarantineRule;
 import uk.gov.ons.census.exceptionmanager.model.dto.BadMessageReport;
 import uk.gov.ons.census.exceptionmanager.model.dto.BadMessageSummary;
 import uk.gov.ons.census.exceptionmanager.model.dto.ExceptionReport;
@@ -54,7 +55,7 @@ public class AdminEndpointTest {
     List<BadMessageReport> badMessageReportList = List.of(badMessageReport);
     when(inMemoryDatabase.getSeenMessageHashes()).thenReturn(testSet);
     when(inMemoryDatabase.getBadMessageReports(anyString())).thenReturn(badMessageReportList);
-    when(inMemoryDatabase.shouldWeSkipThisMessage(anyString())).thenReturn(true);
+    when(inMemoryDatabase.isQuarantined(anyString())).thenReturn(true);
     AdminEndpoint underTest = new AdminEndpoint(inMemoryDatabase, 500);
 
     // When
@@ -63,7 +64,7 @@ public class AdminEndpointTest {
     // Then
     verify(inMemoryDatabase).getSeenMessageHashes();
     verify(inMemoryDatabase).getBadMessageReports(eq("test message hash"));
-    verify(inMemoryDatabase).shouldWeSkipThisMessage(eq("test message hash"));
+    verify(inMemoryDatabase).isQuarantined(eq("test message hash"));
 
     assertThat(actualResponse.getBody()).isNotNull();
     assertThat(actualResponse.getBody().size()).isEqualTo(1);
@@ -187,5 +188,20 @@ public class AdminEndpointTest {
 
     // Then
     verify(inMemoryDatabase).reset();
+  }
+
+  @Test
+  public void testAddQuarantineRule() {
+    // Given
+    InMemoryDatabase inMemoryDatabase = mock(InMemoryDatabase.class);
+    AdminEndpoint underTest = new AdminEndpoint(inMemoryDatabase, 500);
+
+    // When
+    AutoQuarantineRule autoQuarantineRule = new AutoQuarantineRule();
+    autoQuarantineRule.setExpression("true");
+    underTest.addQuarantineRule(autoQuarantineRule);
+
+    // Then
+    verify(inMemoryDatabase).addQuarantineRuleExpression(eq("true"));
   }
 }

--- a/src/test/java/uk/gov/ons/census/exceptionmanager/endpoint/ReportingEndpointTest.java
+++ b/src/test/java/uk/gov/ons/census/exceptionmanager/endpoint/ReportingEndpointTest.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.census.exceptionmanager.endpoint;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -29,13 +30,13 @@ public class ReportingEndpointTest {
     ExceptionReport exceptionReport = new ExceptionReport();
     exceptionReport.setMessageHash(testMessageHash);
 
-    when(inMemoryDatabase.shouldWeSkipThisMessage(anyString())).thenReturn(true);
+    when(inMemoryDatabase.shouldWeSkipThisMessage(any(ExceptionReport.class))).thenReturn(true);
     when(inMemoryDatabase.shouldWePeekThisMessage(anyString())).thenReturn(true);
     when(inMemoryDatabase.shouldWeLogThisMessage(exceptionReport)).thenReturn(true);
 
     ResponseEntity<Response> actualResponse = underTest.reportError(exceptionReport);
 
-    verify(inMemoryDatabase).shouldWeSkipThisMessage(eq(testMessageHash));
+    verify(inMemoryDatabase).shouldWeSkipThisMessage(eq(exceptionReport));
     verify(inMemoryDatabase).shouldWePeekThisMessage(eq(testMessageHash));
     verify(inMemoryDatabase).shouldWeLogThisMessage(eq(exceptionReport));
     assertThat(actualResponse.getBody().isSkipIt()).isTrue();


### PR DESCRIPTION
# Motivation and Context
We want a flexible mechanism for auto-quarantining messages, allowing us to create rules as necessary.

# What has changed
Added an endpoint which we can POST to, in order to create auto quarantine rules. Rules are stored in the DB so that they will survive a restart of the Exception Manager. Rules use Spring Expression Language (SpEL) to give maximum flexibility.

# How to test?
Try creating a rule by running the following CURL:
```
curl --header "Content-Type: application/json" \
  --request POST \
  --data '{"expression":"service == \"Case Processor\""}' \
  http://localhost:8666/quarantinerule
```

It's possible to use the full power of SpEL to create complicated rules. See: https://www.baeldung.com/spring-expression-language

For example, the expression to filter only receipt exceptions from Case Processor, would be:
`service == "Case Processor" and queue == "Case.Responses"`

# Links
Trello: https://trello.com/c/y2f663C6