### PR TITLE
Enhancements to allow replaying messages and other stuff

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,10 @@
       <artifactId>spring-boot-starter-data-jpa</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-amqp</artifactId>
+    </dependency>
+    <dependency>
       <artifactId>spring-web</artifactId>
       <groupId>org.springframework</groupId>
     </dependency>

--- a/src/main/java/uk/gov/ons/census/exceptionmanager/config/AppConfig.java
+++ b/src/main/java/uk/gov/ons/census/exceptionmanager/config/AppConfig.java
@@ -2,12 +2,28 @@ package uk.gov.ons.census.exceptionmanager.config;
 
 import java.util.TimeZone;
 import javax.annotation.PostConstruct;
+import org.springframework.amqp.core.AmqpAdmin;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitAdmin;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class AppConfig implements WebMvcConfigurer {
+  @Bean
+  public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory) {
+    RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
+    rabbitTemplate.setChannelTransacted(true);
+    return rabbitTemplate;
+  }
+
+  @Bean
+  public AmqpAdmin amqpAdmin(ConnectionFactory connectionFactory) {
+    return new RabbitAdmin(connectionFactory);
+  }
 
   @PostConstruct
   public void init() {

--- a/src/main/java/uk/gov/ons/census/exceptionmanager/endpoint/AdminEndpoint.java
+++ b/src/main/java/uk/gov/ons/census/exceptionmanager/endpoint/AdminEndpoint.java
@@ -1,16 +1,25 @@
 package uk.gov.ons.census.exceptionmanager.endpoint;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
 import javax.transaction.Transactional;
+import org.springframework.amqp.core.MessageDeliveryMode;
+import org.springframework.amqp.core.MessagePostProcessor;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -20,17 +29,26 @@ import uk.gov.ons.census.exceptionmanager.model.dto.AutoQuarantineRule;
 import uk.gov.ons.census.exceptionmanager.model.dto.BadMessageReport;
 import uk.gov.ons.census.exceptionmanager.model.dto.BadMessageSummary;
 import uk.gov.ons.census.exceptionmanager.model.dto.SkippedMessage;
+import uk.gov.ons.census.exceptionmanager.model.entity.QuarantinedMessage;
+import uk.gov.ons.census.exceptionmanager.model.repository.QuarantinedMessageRepository;
 import uk.gov.ons.census.exceptionmanager.persistence.InMemoryDatabase;
 
 @RestController
 public class AdminEndpoint {
   private final InMemoryDatabase inMemoryDatabase;
   private final int peekTimeout;
+  private final QuarantinedMessageRepository quarantinedMessageRepository;
+  private final RabbitTemplate rabbitTemplate;
 
   public AdminEndpoint(
-      InMemoryDatabase inMemoryDatabase, @Value("${peek.timeout}") int peekTimeout) {
+      InMemoryDatabase inMemoryDatabase,
+      @Value("${peek.timeout}") int peekTimeout,
+      QuarantinedMessageRepository quarantinedMessageRepository,
+      RabbitTemplate rabbitTemplate) {
     this.inMemoryDatabase = inMemoryDatabase;
     this.peekTimeout = peekTimeout;
+    this.quarantinedMessageRepository = quarantinedMessageRepository;
+    this.rabbitTemplate = rabbitTemplate;
   }
 
   @GetMapping(path = "/badmessages")
@@ -132,9 +150,64 @@ public class AdminEndpoint {
     inMemoryDatabase.reset();
   }
 
+  @GetMapping(path = "/quarantinerule")
+  public ResponseEntity<List<AutoQuarantineRule>> getQuarantineRules() {
+    List<uk.gov.ons.census.exceptionmanager.model.entity.AutoQuarantineRule> quarantineRules =
+        inMemoryDatabase.getQuarantineRules();
+    List<AutoQuarantineRule> result =
+        quarantineRules.stream()
+            .map(
+                rule -> {
+                  AutoQuarantineRule mappedRule = new AutoQuarantineRule();
+                  mappedRule.setExpression(rule.getExpression());
+                  return mappedRule;
+                })
+            .collect(Collectors.toList());
+    return ResponseEntity.status(HttpStatus.OK).body(result);
+  }
+
   @Transactional
   @PostMapping(path = "/quarantinerule")
   public void addQuarantineRule(@RequestBody AutoQuarantineRule autoQuarantineRule) {
     inMemoryDatabase.addQuarantineRuleExpression(autoQuarantineRule.getExpression());
+  }
+
+  @Transactional
+  @DeleteMapping(path = "/quarantinerule/{id}")
+  public void deleteQuarantineRules(@PathVariable("id") String id) {
+    inMemoryDatabase.deleteQuarantineRule(id);
+  }
+
+  @Transactional
+  @GetMapping(path = "/replayquarantinedmessage/{id}")
+  public void replaySkippedMessage(@PathVariable("id") String id) {
+    Optional<QuarantinedMessage> quarantinedMessageOpt =
+        quarantinedMessageRepository.findById(UUID.fromString(id));
+    if (quarantinedMessageOpt.isPresent()) {
+      QuarantinedMessage quarantinedMessage = quarantinedMessageOpt.get();
+
+      if (quarantinedMessage.getRoutingKey().equals("none")) {
+        throw new RuntimeException("Cannot replay PubSub messages... yet"); // TODO
+      }
+
+      MessagePostProcessor mpp =
+          message -> {
+            message.getMessageProperties().setDeliveryMode(MessageDeliveryMode.PERSISTENT);
+            message.getMessageProperties().setContentType(quarantinedMessage.getContentType());
+            for (Entry<String, JsonNode> headerEntry : quarantinedMessage.getHeaders().entrySet()) {
+              message
+                  .getMessageProperties()
+                  .setHeader(headerEntry.getKey(), headerEntry.getValue());
+            }
+            return message;
+          };
+
+      rabbitTemplate.convertAndSend(
+          quarantinedMessage.getQueue(), quarantinedMessage.getMessagePayload(), mpp);
+
+      quarantinedMessageRepository.delete(quarantinedMessage);
+    } else {
+      throw new RuntimeException("Cannot find quarantined message with ID: " + id);
+    }
   }
 }

--- a/src/main/java/uk/gov/ons/census/exceptionmanager/model/entity/QuarantinedMessage.java
+++ b/src/main/java/uk/gov/ons/census/exceptionmanager/model/entity/QuarantinedMessage.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.census.exceptionmanager.model.entity;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
 import java.time.OffsetDateTime;
 import java.util.Map;
@@ -41,7 +42,7 @@ public class QuarantinedMessage {
 
   @Type(type = "jsonb")
   @Column(columnDefinition = "jsonb")
-  private Map<String, String> headers;
+  private Map<String, JsonNode> headers;
 
   @Type(type = "jsonb")
   @Column(columnDefinition = "jsonb")

--- a/src/main/java/uk/gov/ons/census/exceptionmanager/persistence/CachingDataStore.java
+++ b/src/main/java/uk/gov/ons/census/exceptionmanager/persistence/CachingDataStore.java
@@ -26,8 +26,8 @@ import uk.gov.ons.census.exceptionmanager.model.entity.AutoQuarantineRule;
 import uk.gov.ons.census.exceptionmanager.model.repository.AutoQuarantineRuleRepository;
 
 @Component
-public class InMemoryDatabase {
-  private static final Logger log = LoggerFactory.getLogger(InMemoryDatabase.class);
+public class CachingDataStore {
+  private static final Logger log = LoggerFactory.getLogger(CachingDataStore.class);
   private Map<ExceptionReport, ExceptionStats> seenExceptions = new HashMap<>();
   private Map<String, List<ExceptionReport>> messageExceptionReports = new HashMap<>();
   private Set<String> messagesToSkip = new HashSet<>();
@@ -37,7 +37,7 @@ public class InMemoryDatabase {
   private List<Expression> autoQuarantineExpressions = new LinkedList<>();
   private final AutoQuarantineRuleRepository quarantineRuleRepository;
 
-  public InMemoryDatabase(AutoQuarantineRuleRepository quarantineRuleRepository) {
+  public CachingDataStore(AutoQuarantineRuleRepository quarantineRuleRepository) {
     this.quarantineRuleRepository = quarantineRuleRepository;
 
     List<AutoQuarantineRule> autoQuarantineRules = quarantineRuleRepository.findAll();

--- a/src/main/java/uk/gov/ons/census/exceptionmanager/persistence/InMemoryDatabase.java
+++ b/src/main/java/uk/gov/ons/census/exceptionmanager/persistence/InMemoryDatabase.java
@@ -169,4 +169,21 @@ public class InMemoryDatabase {
 
     autoQuarantineExpressions.add(spelExpression);
   }
+
+  public List<AutoQuarantineRule> getQuarantineRules() {
+    return quarantineRuleRepository.findAll();
+  }
+
+  public void deleteQuarantineRule(String id) {
+    quarantineRuleRepository.deleteById(UUID.fromString(id));
+    List<AutoQuarantineRule> rules = quarantineRuleRepository.findAll();
+    List<Expression> newRules = new LinkedList<>();
+    for (AutoQuarantineRule rule : rules) {
+      ExpressionParser expressionParser = new SpelExpressionParser();
+      Expression spelExpression = expressionParser.parseExpression(rule.getExpression());
+      newRules.add(spelExpression);
+    }
+
+    autoQuarantineExpressions = newRules;
+  }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,6 +27,13 @@ spring:
           lob:
             non_contextual_creation: true
 
+  rabbitmq:
+    username: guest
+    password: guest
+    host: localhost
+    port: 6672
+    virtualhost: /
+
 management:
   endpoints:
     enabled-by-default: true

--- a/src/test/java/uk/gov/ons/census/exceptionmanager/endpoint/AdminEndpointIT.java
+++ b/src/test/java/uk/gov/ons/census/exceptionmanager/endpoint/AdminEndpointIT.java
@@ -14,7 +14,6 @@ import java.util.UUID;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
@@ -23,6 +22,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.ons.census.exceptionmanager.model.dto.SkippedMessage;
 import uk.gov.ons.census.exceptionmanager.model.entity.QuarantinedMessage;
 import uk.gov.ons.census.exceptionmanager.model.repository.QuarantinedMessageRepository;
+import uk.gov.ons.census.exceptionmanager.persistence.CachingDataStore;
 import uk.gov.ons.census.exceptionmanager.testutil.QueueSpy;
 import uk.gov.ons.census.exceptionmanager.testutil.RabbitQueueHelper;
 
@@ -39,14 +39,15 @@ public class AdminEndpointIT {
 
   @Autowired private RabbitQueueHelper rabbitQueueHelper;
 
-  @Autowired RabbitTemplate rabbitTemplate;
+  @Autowired private QuarantinedMessageRepository quarantinedMessageRepository;
 
-  @Autowired QuarantinedMessageRepository quarantinedMessageRepository;
+  @Autowired private CachingDataStore cachingDataStore;
 
   @Before
   public void setUp() {
     quarantinedMessageRepository.deleteAllInBatch();
     rabbitQueueHelper.purgeQueue(TEST_QUEUE_NAME);
+    cachingDataStore.reset();
   }
 
   @Test

--- a/src/test/java/uk/gov/ons/census/exceptionmanager/endpoint/AdminEndpointIT.java
+++ b/src/test/java/uk/gov/ons/census/exceptionmanager/endpoint/AdminEndpointIT.java
@@ -10,13 +10,21 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.ons.census.exceptionmanager.model.dto.SkippedMessage;
+import uk.gov.ons.census.exceptionmanager.model.entity.QuarantinedMessage;
+import uk.gov.ons.census.exceptionmanager.model.repository.QuarantinedMessageRepository;
+import uk.gov.ons.census.exceptionmanager.testutil.QueueSpy;
+import uk.gov.ons.census.exceptionmanager.testutil.RabbitQueueHelper;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -25,11 +33,21 @@ public class AdminEndpointIT {
   private static final String TEST_MESSAGE_HASH =
       "9af5350f1e61149cd0bb7dfa5efae46f224aaaffed729b220d63e0fe5a8bf4b9";
   private static final ObjectMapper objectMapper = new ObjectMapper();
+  private static final String TEST_QUEUE_NAME = "testQueue";
 
   @LocalServerPort private int port;
 
+  @Autowired private RabbitQueueHelper rabbitQueueHelper;
+
+  @Autowired RabbitTemplate rabbitTemplate;
+
+  @Autowired QuarantinedMessageRepository quarantinedMessageRepository;
+
   @Before
-  public void setUp() {}
+  public void setUp() {
+    quarantinedMessageRepository.deleteAllInBatch();
+    rabbitQueueHelper.purgeQueue(TEST_QUEUE_NAME);
+  }
 
   @Test
   public void testGetBadMessages() throws Exception {
@@ -61,5 +79,48 @@ public class AdminEndpointIT {
 
     List actualResponse = objectMapper.readValue(response.getBody(), List.class);
     assertThat(actualResponse.size()).isEqualTo(0);
+  }
+
+  @Test
+  public void testReplayQuarantinedMessage() throws Exception {
+    try (QueueSpy testQueueSpy = rabbitQueueHelper.listen(TEST_QUEUE_NAME)) {
+      SkippedMessage skippedMessage = new SkippedMessage();
+      skippedMessage.setMessageHash(TEST_MESSAGE_HASH);
+      skippedMessage.setQueue(TEST_QUEUE_NAME);
+      skippedMessage.setContentType("application/xml");
+      skippedMessage.setHeaders(Map.of("foo", "bar"));
+      skippedMessage.setMessagePayload("<noodle>poodle</noodle>".getBytes());
+      skippedMessage.setRoutingKey("test routing key");
+      skippedMessage.setService("test service");
+      skippedMessage.setSkippedTimestamp(null);
+
+      Map<String, String> headers = new HashMap<>();
+      headers.put("accept", "application/json");
+      headers.put("Content-Type", "application/json");
+      HttpResponse<String> response =
+          Unirest.post(String.format("http://localhost:%d/storeskippedmessage", port))
+              .headers(headers)
+              .body(objectMapper.writeValueAsString(skippedMessage))
+              .asString();
+
+      assertThat(response.getStatus()).isEqualTo(OK.value());
+
+      List<QuarantinedMessage> quarantinedMessages = quarantinedMessageRepository.findAll();
+      assertThat(quarantinedMessages.size()).isEqualTo(1);
+
+      UUID qmId = quarantinedMessages.get(0).getId();
+
+      response =
+          Unirest.get(String.format("http://localhost:%d/replayquarantinedmessage/%s", port, qmId))
+              .headers(headers)
+              .asString();
+
+      assertThat(response.getStatus()).isEqualTo(OK.value());
+
+      String actualMessage = testQueueSpy.checkExpectedMessageReceived();
+      assertThat(actualMessage).isEqualTo("<noodle>poodle</noodle>");
+
+      assertThat(quarantinedMessageRepository.findAll().size()).isEqualTo(0);
+    }
   }
 }

--- a/src/test/java/uk/gov/ons/census/exceptionmanager/endpoint/ReportingEndpointIT.java
+++ b/src/test/java/uk/gov/ons/census/exceptionmanager/endpoint/ReportingEndpointIT.java
@@ -26,7 +26,7 @@ import uk.gov.ons.census.exceptionmanager.model.dto.SkippedMessage;
 import uk.gov.ons.census.exceptionmanager.model.entity.QuarantinedMessage;
 import uk.gov.ons.census.exceptionmanager.model.repository.AutoQuarantineRuleRepository;
 import uk.gov.ons.census.exceptionmanager.model.repository.QuarantinedMessageRepository;
-import uk.gov.ons.census.exceptionmanager.persistence.InMemoryDatabase;
+import uk.gov.ons.census.exceptionmanager.persistence.CachingDataStore;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -36,7 +36,7 @@ public class ReportingEndpointIT {
       "9af5350f1e61149cd0bb7dfa5efae46f224aaaffed729b220d63e0fe5a8bf4b8";
   private static final ObjectMapper objectMapper = new ObjectMapper();
 
-  @Autowired private InMemoryDatabase inMemoryDatabase;
+  @Autowired private CachingDataStore cachingDataStore;
   @Autowired private QuarantinedMessageRepository quarantinedMessageRepository;
   @Autowired private AutoQuarantineRuleRepository autoQuarantineRuleRepository;
 
@@ -45,7 +45,7 @@ public class ReportingEndpointIT {
   @Before
   public void setUp() {
     quarantinedMessageRepository.deleteAllInBatch();
-    inMemoryDatabase.reset();
+    cachingDataStore.reset();
     autoQuarantineRuleRepository.deleteAllInBatch();
   }
 
@@ -74,7 +74,7 @@ public class ReportingEndpointIT {
     assertThat(actualResponse.isLogIt()).isTrue();
     assertThat(actualResponse.isPeek()).isFalse();
 
-    assertThat(inMemoryDatabase.getBadMessageReports(TEST_MESSAGE_HASH).size()).isEqualTo(1);
+    assertThat(cachingDataStore.getBadMessageReports(TEST_MESSAGE_HASH).size()).isEqualTo(1);
   }
 
   @Test
@@ -113,7 +113,7 @@ public class ReportingEndpointIT {
     assertThat(actualResponse.isLogIt()).isTrue();
     assertThat(actualResponse.isPeek()).isFalse();
 
-    assertThat(inMemoryDatabase.getBadMessageReports(TEST_MESSAGE_HASH).size()).isEqualTo(1);
+    assertThat(cachingDataStore.getBadMessageReports(TEST_MESSAGE_HASH).size()).isEqualTo(1);
   }
 
   @Test
@@ -133,7 +133,7 @@ public class ReportingEndpointIT {
 
     assertThat(response.getStatus()).isEqualTo(OK.value());
 
-    assertThat(inMemoryDatabase.getPeekedMessage(TEST_MESSAGE_HASH))
+    assertThat(cachingDataStore.getPeekedMessage(TEST_MESSAGE_HASH))
         .isEqualTo(peek.getMessagePayload());
   }
 
@@ -162,7 +162,7 @@ public class ReportingEndpointIT {
 
     assertThat(response.getStatus()).isEqualTo(OK.value());
 
-    List<SkippedMessage> skippedMessages = inMemoryDatabase.getSkippedMessages(TEST_MESSAGE_HASH);
+    List<SkippedMessage> skippedMessages = cachingDataStore.getSkippedMessages(TEST_MESSAGE_HASH);
     assertThat(skippedMessages.size()).isEqualTo(1);
     assertThat(skippedMessages.get(0)).isEqualTo(skippedMessage);
 

--- a/src/test/java/uk/gov/ons/census/exceptionmanager/endpoint/ReportingEndpointIT.java
+++ b/src/test/java/uk/gov/ons/census/exceptionmanager/endpoint/ReportingEndpointIT.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.HttpStatus.OK;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.TextNode;
 import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.Unirest;
 import java.util.HashMap;
@@ -32,7 +33,7 @@ import uk.gov.ons.census.exceptionmanager.persistence.InMemoryDatabase;
 @ActiveProfiles("test")
 public class ReportingEndpointIT {
   private static final String TEST_MESSAGE_HASH =
-      "9af5350f1e61149cd0bb7dfa5efae46f224aaaffed729b220d63e0fe5a8bf4b9";
+      "9af5350f1e61149cd0bb7dfa5efae46f224aaaffed729b220d63e0fe5a8bf4b8";
   private static final ObjectMapper objectMapper = new ObjectMapper();
 
   @Autowired private InMemoryDatabase inMemoryDatabase;
@@ -169,7 +170,9 @@ public class ReportingEndpointIT {
     assertThat(allQuarantinedMessages.size()).isEqualTo(1);
     QuarantinedMessage quarantinedMessage = allQuarantinedMessages.get(0);
     assertThat(quarantinedMessage.getContentType()).isEqualTo(skippedMessage.getContentType());
-    assertThat(quarantinedMessage.getHeaders()).isEqualTo(skippedMessage.getHeaders());
+    assertThat(quarantinedMessage.getHeaders().size())
+        .isEqualTo(skippedMessage.getHeaders().size());
+    assertThat(quarantinedMessage.getHeaders().get("foo")).isEqualTo(new TextNode("bar"));
     assertThat(quarantinedMessage.getMessagePayload())
         .isEqualTo(skippedMessage.getMessagePayload());
     assertThat(quarantinedMessage.getRoutingKey()).isEqualTo(skippedMessage.getRoutingKey());

--- a/src/test/java/uk/gov/ons/census/exceptionmanager/persistence/CachingDataStoreTest.java
+++ b/src/test/java/uk/gov/ons/census/exceptionmanager/persistence/CachingDataStoreTest.java
@@ -1,11 +1,14 @@
 package uk.gov.ons.census.exceptionmanager.persistence;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
 import uk.gov.ons.census.exceptionmanager.model.dto.BadMessageReport;
@@ -384,5 +387,37 @@ public class CachingDataStoreTest {
     assertThat(underTest.getBadMessageReports("test message hash")).isEmpty();
     assertThat(underTest.getAllSkippedMessages()).isNotEmpty();
     assertThat(underTest.getAllSkippedMessages()).isNotEmpty();
+  }
+
+  @Test
+  public void testGetQuarantineRules() {
+    // Given
+    List<AutoQuarantineRule> expectedAutoQuarantineRules = Collections.EMPTY_LIST;
+    AutoQuarantineRuleRepository autoQuarantineRuleRepository =
+        mock(AutoQuarantineRuleRepository.class);
+    when(autoQuarantineRuleRepository.findAll()).thenReturn(expectedAutoQuarantineRules);
+    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository);
+
+    // When
+    List<AutoQuarantineRule> actualQuarantineRules = underTest.getQuarantineRules();
+
+    // Then
+    assertThat(actualQuarantineRules).isEqualTo(expectedAutoQuarantineRules);
+  }
+
+  @Test
+  public void testDeleteQuarantineRule() {
+    List<AutoQuarantineRule> expectedAutoQuarantineRules = Collections.EMPTY_LIST;
+    AutoQuarantineRuleRepository autoQuarantineRuleRepository =
+        mock(AutoQuarantineRuleRepository.class);
+    when(autoQuarantineRuleRepository.findAll()).thenReturn(expectedAutoQuarantineRules);
+    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository);
+    UUID testId = UUID.randomUUID();
+
+    // When
+    underTest.deleteQuarantineRule(testId.toString());
+
+    // Then
+    verify(autoQuarantineRuleRepository).deleteById(eq(testId));
   }
 }

--- a/src/test/java/uk/gov/ons/census/exceptionmanager/persistence/CachingDataStoreTest.java
+++ b/src/test/java/uk/gov/ons/census/exceptionmanager/persistence/CachingDataStoreTest.java
@@ -16,13 +16,13 @@ import uk.gov.ons.census.exceptionmanager.model.dto.SkippedMessage;
 import uk.gov.ons.census.exceptionmanager.model.entity.AutoQuarantineRule;
 import uk.gov.ons.census.exceptionmanager.model.repository.AutoQuarantineRuleRepository;
 
-public class InMemoryDatabaseTest {
+public class CachingDataStoreTest {
   @Test
   public void testUpdateStats() {
     AutoQuarantineRuleRepository autoQuarantineRuleRepository =
         mock(AutoQuarantineRuleRepository.class);
     when(autoQuarantineRuleRepository.findAll()).thenReturn(Collections.emptyList());
-    InMemoryDatabase underTest = new InMemoryDatabase(autoQuarantineRuleRepository);
+    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository);
     ExceptionReport exceptionReport = new ExceptionReport();
     exceptionReport.setMessageHash("test message hash");
     exceptionReport.setExceptionClass("test class");
@@ -48,7 +48,7 @@ public class InMemoryDatabaseTest {
     AutoQuarantineRuleRepository autoQuarantineRuleRepository =
         mock(AutoQuarantineRuleRepository.class);
     when(autoQuarantineRuleRepository.findAll()).thenReturn(Collections.emptyList());
-    InMemoryDatabase underTest = new InMemoryDatabase(autoQuarantineRuleRepository);
+    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository);
     ExceptionReport exceptionReport = new ExceptionReport();
     exceptionReport.setMessageHash("test message hash");
     exceptionReport.setExceptionClass("test class");
@@ -75,7 +75,7 @@ public class InMemoryDatabaseTest {
     AutoQuarantineRuleRepository autoQuarantineRuleRepository =
         mock(AutoQuarantineRuleRepository.class);
     when(autoQuarantineRuleRepository.findAll()).thenReturn(Collections.emptyList());
-    InMemoryDatabase underTest = new InMemoryDatabase(autoQuarantineRuleRepository);
+    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository);
     ExceptionReport exceptionReportOne = new ExceptionReport();
     exceptionReportOne.setMessageHash("test message hash");
     exceptionReportOne.setExceptionClass("test class");
@@ -118,7 +118,7 @@ public class InMemoryDatabaseTest {
     AutoQuarantineRuleRepository autoQuarantineRuleRepository =
         mock(AutoQuarantineRuleRepository.class);
     when(autoQuarantineRuleRepository.findAll()).thenReturn(Collections.emptyList());
-    InMemoryDatabase underTest = new InMemoryDatabase(autoQuarantineRuleRepository);
+    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository);
     ExceptionReport exceptionReport = new ExceptionReport();
     exceptionReport.setMessageHash("test message hash");
     exceptionReport.setExceptionClass("test class");
@@ -138,7 +138,7 @@ public class InMemoryDatabaseTest {
     AutoQuarantineRuleRepository autoQuarantineRuleRepository =
         mock(AutoQuarantineRuleRepository.class);
     when(autoQuarantineRuleRepository.findAll()).thenReturn(Collections.emptyList());
-    InMemoryDatabase underTest = new InMemoryDatabase(autoQuarantineRuleRepository);
+    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository);
     ExceptionReport exceptionReport = new ExceptionReport();
     exceptionReport.setMessageHash("test message hash");
     exceptionReport.setExceptionClass("test class");
@@ -164,7 +164,7 @@ public class InMemoryDatabaseTest {
     AutoQuarantineRule rule = new AutoQuarantineRule();
     rule.setExpression("exceptionClass == \"test class\" and queue == \"test queue\"");
     when(autoQuarantineRuleRepository.findAll()).thenReturn(Collections.singletonList(rule));
-    InMemoryDatabase underTest = new InMemoryDatabase(autoQuarantineRuleRepository);
+    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository);
     ExceptionReport exceptionReport = new ExceptionReport();
     exceptionReport.setMessageHash("test message hash");
     exceptionReport.setExceptionClass("test class");
@@ -182,7 +182,7 @@ public class InMemoryDatabaseTest {
     AutoQuarantineRule rule = new AutoQuarantineRule();
     rule.setExpression("exceptionMessage.contains('message')");
     when(autoQuarantineRuleRepository.findAll()).thenReturn(Collections.singletonList(rule));
-    InMemoryDatabase underTest = new InMemoryDatabase(autoQuarantineRuleRepository);
+    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository);
     ExceptionReport exceptionReport = new ExceptionReport();
     exceptionReport.setMessageHash("test message hash");
     exceptionReport.setExceptionClass("test class");
@@ -200,7 +200,7 @@ public class InMemoryDatabaseTest {
     AutoQuarantineRule rule = new AutoQuarantineRule();
     rule.setExpression("exceptionClass == \"noodle\" and queue == \"test queue\"");
     when(autoQuarantineRuleRepository.findAll()).thenReturn(Collections.singletonList(rule));
-    InMemoryDatabase underTest = new InMemoryDatabase(autoQuarantineRuleRepository);
+    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository);
     ExceptionReport exceptionReport = new ExceptionReport();
     exceptionReport.setMessageHash("test message hash");
     exceptionReport.setExceptionClass("test class");
@@ -216,7 +216,7 @@ public class InMemoryDatabaseTest {
     AutoQuarantineRuleRepository autoQuarantineRuleRepository =
         mock(AutoQuarantineRuleRepository.class);
     when(autoQuarantineRuleRepository.findAll()).thenReturn(Collections.emptyList());
-    InMemoryDatabase underTest = new InMemoryDatabase(autoQuarantineRuleRepository);
+    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository);
     ExceptionReport exceptionReport = new ExceptionReport();
     exceptionReport.setMessageHash("test message hash");
     exceptionReport.setExceptionClass("test class");
@@ -240,7 +240,7 @@ public class InMemoryDatabaseTest {
     AutoQuarantineRuleRepository autoQuarantineRuleRepository =
         mock(AutoQuarantineRuleRepository.class);
     when(autoQuarantineRuleRepository.findAll()).thenReturn(Collections.emptyList());
-    InMemoryDatabase underTest = new InMemoryDatabase(autoQuarantineRuleRepository);
+    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository);
     ExceptionReport exceptionReportOne = new ExceptionReport();
     exceptionReportOne.setMessageHash("test message hash");
     exceptionReportOne.setExceptionClass("test class");
@@ -271,7 +271,7 @@ public class InMemoryDatabaseTest {
     AutoQuarantineRuleRepository autoQuarantineRuleRepository =
         mock(AutoQuarantineRuleRepository.class);
     when(autoQuarantineRuleRepository.findAll()).thenReturn(Collections.emptyList());
-    InMemoryDatabase underTest = new InMemoryDatabase(autoQuarantineRuleRepository);
+    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository);
     Peek peek = new Peek();
     peek.setMessageHash("test message hash");
     peek.setMessagePayload("test message".getBytes());
@@ -286,7 +286,7 @@ public class InMemoryDatabaseTest {
     AutoQuarantineRuleRepository autoQuarantineRuleRepository =
         mock(AutoQuarantineRuleRepository.class);
     when(autoQuarantineRuleRepository.findAll()).thenReturn(Collections.emptyList());
-    InMemoryDatabase underTest = new InMemoryDatabase(autoQuarantineRuleRepository);
+    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository);
     SkippedMessage skippedMessage = new SkippedMessage();
     skippedMessage.setMessageHash("test message hash");
     underTest.storeSkippedMessage(skippedMessage);
@@ -302,7 +302,7 @@ public class InMemoryDatabaseTest {
     AutoQuarantineRuleRepository autoQuarantineRuleRepository =
         mock(AutoQuarantineRuleRepository.class);
     when(autoQuarantineRuleRepository.findAll()).thenReturn(Collections.emptyList());
-    InMemoryDatabase underTest = new InMemoryDatabase(autoQuarantineRuleRepository);
+    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository);
     SkippedMessage skippedMessageOne = new SkippedMessage();
     skippedMessageOne.setMessageHash("test message hash");
     skippedMessageOne.setQueue("test queue one");
@@ -322,7 +322,7 @@ public class InMemoryDatabaseTest {
     AutoQuarantineRuleRepository autoQuarantineRuleRepository =
         mock(AutoQuarantineRuleRepository.class);
     when(autoQuarantineRuleRepository.findAll()).thenReturn(Collections.emptyList());
-    InMemoryDatabase underTest = new InMemoryDatabase(autoQuarantineRuleRepository);
+    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository);
     SkippedMessage skippedMessageOne = new SkippedMessage();
     skippedMessageOne.setMessageHash("test message hash");
     skippedMessageOne.setQueue("test queue one");

--- a/src/test/java/uk/gov/ons/census/exceptionmanager/testutil/QueueSpy.java
+++ b/src/test/java/uk/gov/ons/census/exceptionmanager/testutil/QueueSpy.java
@@ -1,0 +1,37 @@
+package uk.gov.ons.census.exceptionmanager.testutil;
+
+import static org.junit.Assert.assertNotNull;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.io.IOException;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
+
+@AllArgsConstructor
+public class QueueSpy implements AutoCloseable {
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+
+  static {
+    objectMapper.registerModule(new JavaTimeModule());
+    objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+  }
+
+  @Getter private BlockingQueue<String> queue;
+  private SimpleMessageListenerContainer container;
+
+  @Override
+  public void close() throws Exception {
+    container.stop();
+  }
+
+  public String checkExpectedMessageReceived() throws IOException, InterruptedException {
+    String actualMessage = queue.poll(20, TimeUnit.SECONDS);
+    assertNotNull("Did not receive message before timeout", actualMessage);
+    return actualMessage;
+  }
+}

--- a/src/test/java/uk/gov/ons/census/exceptionmanager/testutil/RabbitQueueHelper.java
+++ b/src/test/java/uk/gov/ons/census/exceptionmanager/testutil/RabbitQueueHelper.java
@@ -1,0 +1,55 @@
+package uk.gov.ons.census.exceptionmanager.testutil;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import org.springframework.amqp.core.AmqpAdmin;
+import org.springframework.amqp.core.MessageListener;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Component;
+import org.springframework.test.context.ActiveProfiles;
+
+@Component
+@ActiveProfiles("test")
+@EnableRetry
+public class RabbitQueueHelper {
+  @Autowired private ConnectionFactory connectionFactory;
+
+  @Autowired private RabbitTemplate rabbitTemplate;
+
+  @Autowired private AmqpAdmin amqpAdmin;
+
+  public QueueSpy listen(String queueName) {
+    return listen(queueName, 50);
+  }
+
+  public QueueSpy listen(String queueName, int capacity) {
+    BlockingQueue<String> transfer = new ArrayBlockingQueue(capacity);
+
+    MessageListener messageListener =
+        message -> {
+          String msgStr = new String(message.getBody());
+          transfer.add(msgStr);
+        };
+    SimpleMessageListenerContainer container =
+        new SimpleMessageListenerContainer(connectionFactory);
+    container.setMessageListener(messageListener);
+    container.setQueueNames(queueName);
+    container.start();
+
+    return new QueueSpy(transfer, container);
+  }
+
+  @Retryable(
+      value = {java.io.IOException.class},
+      maxAttempts = 10,
+      backoff = @Backoff(delay = 5000))
+  public void purgeQueue(String queueName) {
+    amqpAdmin.purgeQueue(queueName);
+  }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,3 +1,6 @@
 spring:
   datasource:
     url: jdbc:postgresql://localhost:15432/postgres
+
+  rabbitmq:
+    port: 35672

--- a/src/test/resources/definitions.json
+++ b/src/test/resources/definitions.json
@@ -1,0 +1,37 @@
+{
+  "rabbit_version": "3.6.10",
+  "users": [
+    {
+      "name": "guest",
+      "password_hash": "pLp57gHAKtlBTfp0HTq5Gnn/UXdhQNrj1OplYY5uJ0kzDEFY",
+      "hashing_algorithm": "rabbit_password_hashing_sha256",
+      "tags": "administrator"
+    }
+  ],
+  "vhosts": [
+    {
+      "name": "/"
+    }
+  ],
+  "permissions": [
+    {
+      "user": "guest",
+      "vhost": "/",
+      "configure": ".*",
+      "write": ".*",
+      "read": ".*"
+    }
+  ],
+  "parameters": [],
+  "global_parameters": [],
+  "policies": [],
+  "queues": [
+    {
+      "name": "testQueue",
+      "vhost": "/",
+      "durable": true,
+      "auto_delete": false,
+      "arguments": {}
+    }
+  ]
+}

--- a/src/test/resources/docker-compose.yml
+++ b/src/test/resources/docker-compose.yml
@@ -11,3 +11,17 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+
+  rabbitmq:
+    container_name: rabbitmq-exceptionmanager-it
+    image: rabbitmq:3.6.10-management
+    ports:
+      - "34369:4369"
+      - "55672:25672"
+      - "35671:5671"
+      - "35672:5672"
+      - "46671:15671"
+      - "46672:15672"
+    volumes:
+      - ./rabbitmq.config:/etc/rabbitmq/rabbitmq.config:ro
+      - ./definitions.json:/opt/definitions.json:ro

--- a/src/test/resources/rabbitmq.config
+++ b/src/test/resources/rabbitmq.config
@@ -1,0 +1,12 @@
+[
+   {rabbit, [
+      {loopback_users, []},
+      {vm_memory_high_watermark, 0.7},
+      {vm_memory_high_watermark_paging_ratio, 0.8},
+      {log_levels, [{channel, warning}, {connection, warning}, {federation, warning}, {mirroring, info}]},
+      {heartbeat, 10}
+    ]},
+    {rabbitmq_management, [
+        {load_definitions, "/opt/definitions.json"}
+    ]}
+].


### PR DESCRIPTION
# Motivation and Context
We're slowly improving the capabilities of our operational tooling. This wave of enhancement adds the ability to do various things, including replaying quarantined messages.

# What has changed
Added some new endpoints the the API.

# How to test?
Try quarantining a message, then replay it by hitting the `/replayquarantinedmessage/<id>` endpoint... the message should pop back onto the Rabbit queue it came from (but beware - it might get skipped again unless you reset the exception manager).

You can also try out the endpoints to get all the auto quarantine rules, or delete an auto quarantine rule, if that's your sort of thing.

# Links
Trello: https://trello.com/c/whSpMIJG