### PR TITLE
Allow retry before logging & filter exceptions based on seen count

### DIFF
--- a/src/main/java/uk/gov/ons/census/exceptionmanager/endpoint/AdminEndpoint.java
+++ b/src/main/java/uk/gov/ons/census/exceptionmanager/endpoint/AdminEndpoint.java
@@ -168,7 +168,7 @@ public class AdminEndpoint {
                   AutoQuarantineRule mappedRule = new AutoQuarantineRule();
                   mappedRule.setExpression(rule.getExpression());
                   mappedRule.setQuarantine(rule.isQuarantine());
-                  mappedRule.setDoNotLog(rule.isDoNotLog());
+                  mappedRule.setSuppressLogging(rule.isSuppressLogging());
                   mappedRule.setThrowAway(rule.isThrowAway());
                   mappedRule.setRuleExpiryDateTime(rule.getRuleExpiryDateTime());
                   return mappedRule;
@@ -182,7 +182,7 @@ public class AdminEndpoint {
   public void addQuarantineRule(@RequestBody AutoQuarantineRule autoQuarantineRule) {
     cachingDataStore.addQuarantineRuleExpression(
         autoQuarantineRule.getExpression(),
-        autoQuarantineRule.isDoNotLog(),
+        autoQuarantineRule.isSuppressLogging(),
         autoQuarantineRule.isQuarantine(),
         autoQuarantineRule.isThrowAway(),
         autoQuarantineRule.getRuleExpiryDateTime());

--- a/src/main/java/uk/gov/ons/census/exceptionmanager/endpoint/AdminEndpoint.java
+++ b/src/main/java/uk/gov/ons/census/exceptionmanager/endpoint/AdminEndpoint.java
@@ -167,6 +167,10 @@ public class AdminEndpoint {
                 rule -> {
                   AutoQuarantineRule mappedRule = new AutoQuarantineRule();
                   mappedRule.setExpression(rule.getExpression());
+                  mappedRule.setQuarantine(rule.isQuarantine());
+                  mappedRule.setDoNotLog(rule.isDoNotLog());
+                  mappedRule.setThrowAway(rule.isThrowAway());
+                  mappedRule.setRuleExpiryDateTime(rule.getRuleExpiryDateTime());
                   return mappedRule;
                 })
             .collect(Collectors.toList());

--- a/src/main/java/uk/gov/ons/census/exceptionmanager/endpoint/AdminEndpoint.java
+++ b/src/main/java/uk/gov/ons/census/exceptionmanager/endpoint/AdminEndpoint.java
@@ -176,7 +176,12 @@ public class AdminEndpoint {
   @Transactional
   @PostMapping(path = "/quarantinerule")
   public void addQuarantineRule(@RequestBody AutoQuarantineRule autoQuarantineRule) {
-    cachingDataStore.addQuarantineRuleExpression(autoQuarantineRule.getExpression());
+    cachingDataStore.addQuarantineRuleExpression(
+        autoQuarantineRule.getExpression(),
+        autoQuarantineRule.isDoNotLog(),
+        autoQuarantineRule.isQuarantine(),
+        autoQuarantineRule.isThrowAway(),
+        autoQuarantineRule.getRuleExpiryDateTime());
   }
 
   @Transactional

--- a/src/main/java/uk/gov/ons/census/exceptionmanager/endpoint/ReportingEndpoint.java
+++ b/src/main/java/uk/gov/ons/census/exceptionmanager/endpoint/ReportingEndpoint.java
@@ -45,7 +45,7 @@ public class ReportingEndpoint {
         result.setThrowAway(true); // Don't log, don't quarantine... completely silent
       }
 
-      if (rule.isDoNotLog()) {
+      if (rule.isSuppressLogging()) {
         shouldLog = false;
       }
 

--- a/src/main/java/uk/gov/ons/census/exceptionmanager/endpoint/ReportingEndpoint.java
+++ b/src/main/java/uk/gov/ons/census/exceptionmanager/endpoint/ReportingEndpoint.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.census.exceptionmanager.endpoint;
 
+import java.util.List;
 import java.util.UUID;
 import javax.transaction.Transactional;
 import org.springframework.http.HttpStatus;
@@ -12,6 +13,7 @@ import uk.gov.ons.census.exceptionmanager.model.dto.ExceptionReport;
 import uk.gov.ons.census.exceptionmanager.model.dto.Peek;
 import uk.gov.ons.census.exceptionmanager.model.dto.Response;
 import uk.gov.ons.census.exceptionmanager.model.dto.SkippedMessage;
+import uk.gov.ons.census.exceptionmanager.model.entity.AutoQuarantineRule;
 import uk.gov.ons.census.exceptionmanager.model.entity.QuarantinedMessage;
 import uk.gov.ons.census.exceptionmanager.model.repository.QuarantinedMessageRepository;
 import uk.gov.ons.census.exceptionmanager.persistence.CachingDataStore;
@@ -33,9 +35,28 @@ public class ReportingEndpoint {
     Response result = new Response();
     String messageHash = exceptionReport.getMessageHash();
 
-    result.setSkipIt(cachingDataStore.shouldWeSkipThisMessage(exceptionReport));
+    boolean forceSkip = false;
+    boolean shouldLog = true;
+    List<AutoQuarantineRule> matchingRules = cachingDataStore.findMatchingRules(exceptionReport);
+    for (AutoQuarantineRule rule : matchingRules) {
+      if (rule.isThrowAway()) {
+        forceSkip = true;
+        shouldLog = false;
+        result.setThrowAway(true); // Don't log, don't quarantine... completely silent
+      }
+
+      if (rule.isDoNotLog()) {
+        shouldLog = false;
+      }
+
+      if (rule.isQuarantine()) {
+        forceSkip = true;
+      }
+    }
+
+    result.setSkipIt(forceSkip || cachingDataStore.shouldWeSkipThisMessage(exceptionReport));
     result.setPeek(cachingDataStore.shouldWePeekThisMessage(messageHash));
-    result.setLogIt(cachingDataStore.shouldWeLogThisMessage(exceptionReport));
+    result.setLogIt(shouldLog && cachingDataStore.shouldWeLogThisMessage(exceptionReport));
 
     cachingDataStore.updateStats(exceptionReport);
 

--- a/src/main/java/uk/gov/ons/census/exceptionmanager/model/dto/AutoQuarantineRule.java
+++ b/src/main/java/uk/gov/ons/census/exceptionmanager/model/dto/AutoQuarantineRule.java
@@ -1,8 +1,13 @@
 package uk.gov.ons.census.exceptionmanager.model.dto;
 
+import java.time.OffsetDateTime;
 import lombok.Data;
 
 @Data
 public class AutoQuarantineRule {
   private String expression;
+  private boolean doNotLog;
+  private boolean quarantine;
+  private boolean throwAway;
+  private OffsetDateTime ruleExpiryDateTime;
 }

--- a/src/main/java/uk/gov/ons/census/exceptionmanager/model/dto/AutoQuarantineRule.java
+++ b/src/main/java/uk/gov/ons/census/exceptionmanager/model/dto/AutoQuarantineRule.java
@@ -6,7 +6,7 @@ import lombok.Data;
 @Data
 public class AutoQuarantineRule {
   private String expression;
-  private boolean doNotLog;
+  private boolean suppressLogging;
   private boolean quarantine;
   private boolean throwAway;
   private OffsetDateTime ruleExpiryDateTime;

--- a/src/main/java/uk/gov/ons/census/exceptionmanager/model/dto/ExceptionStats.java
+++ b/src/main/java/uk/gov/ons/census/exceptionmanager/model/dto/ExceptionStats.java
@@ -9,4 +9,5 @@ public class ExceptionStats {
   private Instant firstSeen = Instant.now();
   private Instant lastSeen = Instant.now();
   private AtomicInteger seenCount = new AtomicInteger(1);
+  private boolean loggedAtLeastOnce = false;
 }

--- a/src/main/java/uk/gov/ons/census/exceptionmanager/model/dto/Response.java
+++ b/src/main/java/uk/gov/ons/census/exceptionmanager/model/dto/Response.java
@@ -7,4 +7,5 @@ public class Response {
   private boolean peek = false;
   private boolean logIt = false;
   private boolean skipIt = false;
+  private boolean throwAway = false; // Don't log, don't quarantine
 }

--- a/src/main/java/uk/gov/ons/census/exceptionmanager/model/entity/AutoQuarantineRule.java
+++ b/src/main/java/uk/gov/ons/census/exceptionmanager/model/entity/AutoQuarantineRule.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.census.exceptionmanager.model.entity;
 
+import java.time.OffsetDateTime;
 import java.util.UUID;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -12,4 +13,16 @@ public class AutoQuarantineRule {
   @Id private UUID id;
 
   @Column private String expression;
+
+  @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT false")
+  private boolean doNotLog;
+
+  @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT false")
+  private boolean quarantine;
+
+  @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT false")
+  private boolean throwAway;
+
+  @Column(columnDefinition = "timestamp with time zone")
+  private OffsetDateTime ruleExpiryDateTime;
 }

--- a/src/main/java/uk/gov/ons/census/exceptionmanager/model/entity/AutoQuarantineRule.java
+++ b/src/main/java/uk/gov/ons/census/exceptionmanager/model/entity/AutoQuarantineRule.java
@@ -15,7 +15,7 @@ public class AutoQuarantineRule {
   @Column private String expression;
 
   @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT false")
-  private boolean doNotLog;
+  private boolean suppressLogging;
 
   @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT false")
   private boolean quarantine;

--- a/src/main/java/uk/gov/ons/census/exceptionmanager/persistence/CachingDataStore.java
+++ b/src/main/java/uk/gov/ons/census/exceptionmanager/persistence/CachingDataStore.java
@@ -4,7 +4,6 @@ import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
 import java.time.Instant;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -12,6 +11,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.Expression;
@@ -30,12 +30,12 @@ import uk.gov.ons.census.exceptionmanager.model.repository.AutoQuarantineRuleRep
 @Component
 public class CachingDataStore {
   private static final Logger log = LoggerFactory.getLogger(CachingDataStore.class);
-  private Map<ExceptionReport, ExceptionStats> seenExceptions = new HashMap<>();
-  private Map<String, List<ExceptionReport>> messageExceptionReports = new HashMap<>();
-  private Set<String> messagesToSkip = new HashSet<>();
-  private Set<String> messagesToPeek = new HashSet<>();
-  private Map<String, byte[]> peekedMessages = new HashMap<>();
-  private Map<String, List<SkippedMessage>> skippedMessages = new HashMap<>();
+  private Map<ExceptionReport, ExceptionStats> seenExceptions = new ConcurrentHashMap<>();
+  private Map<String, List<ExceptionReport>> messageExceptionReports = new ConcurrentHashMap<>();
+  private Set<String> messagesToSkip = ConcurrentHashMap.newKeySet();
+  private Set<String> messagesToPeek = ConcurrentHashMap.newKeySet();
+  private Map<String, byte[]> peekedMessages = new ConcurrentHashMap<>();
+  private Map<String, List<SkippedMessage>> skippedMessages = new ConcurrentHashMap<>();
   private List<Expression> autoQuarantineExpressions = new LinkedList<>();
   private final AutoQuarantineRuleRepository quarantineRuleRepository;
   private final int numberOfRetriesBeforeLogging;

--- a/src/main/java/uk/gov/ons/census/exceptionmanager/persistence/CachingDataStore.java
+++ b/src/main/java/uk/gov/ons/census/exceptionmanager/persistence/CachingDataStore.java
@@ -95,12 +95,18 @@ public class CachingDataStore {
   public boolean shouldWeSkipThisMessage(ExceptionReport exceptionReport) {
     EvaluationContext context = new StandardEvaluationContext(exceptionReport);
     for (Expression expression : autoQuarantineExpressions) {
-      Boolean expressionResult = expression.getValue(context, Boolean.class);
-      if (expressionResult != null && expressionResult) {
+      try {
+        Boolean expressionResult = expression.getValue(context, Boolean.class);
+        if (expressionResult != null && expressionResult) {
+          log.with("exception_report", exceptionReport)
+              .with("expression", expression.getExpressionString())
+              .warn("Auto-quarantine message rule matched");
+          return true;
+        }
+      } catch (Exception e) {
         log.with("exception_report", exceptionReport)
             .with("expression", expression.getExpressionString())
-            .warn("Auto-quarantine message rule matched");
-        return true;
+            .warn("Auto-quarantine rule is causing errors", e);
       }
     }
 

--- a/src/main/java/uk/gov/ons/census/exceptionmanager/persistence/CachingDataStore.java
+++ b/src/main/java/uk/gov/ons/census/exceptionmanager/persistence/CachingDataStore.java
@@ -114,7 +114,7 @@ public class CachingDataStore {
         Boolean expressionResult = expression.getValue(context, Boolean.class);
         if (expressionResult != null && expressionResult) {
 
-          if (!autoQuarantineRule.isDoNotLog() && !autoQuarantineRule.isThrowAway()) {
+          if (!autoQuarantineRule.isSuppressLogging() && !autoQuarantineRule.isThrowAway()) {
             log.with("exception_report", exceptionReport)
                 .with("expression", expression.getExpressionString())
                 .warn("Auto-quarantine message rule matched");
@@ -228,7 +228,7 @@ public class CachingDataStore {
     AutoQuarantineRule autoQuarantineRule = new AutoQuarantineRule();
     autoQuarantineRule.setId(UUID.randomUUID());
     autoQuarantineRule.setExpression(expression);
-    autoQuarantineRule.setDoNotLog(doNotLog);
+    autoQuarantineRule.setSuppressLogging(doNotLog);
     autoQuarantineRule.setQuarantine(quarantine);
     autoQuarantineRule.setThrowAway(throwAway);
     autoQuarantineRule.setRuleExpiryDateTime(ruleExpiryDateTime);

--- a/src/main/java/uk/gov/ons/census/exceptionmanager/persistence/CachingDataStore.java
+++ b/src/main/java/uk/gov/ons/census/exceptionmanager/persistence/CachingDataStore.java
@@ -96,7 +96,7 @@ public class CachingDataStore {
     EvaluationContext context = new StandardEvaluationContext(exceptionReport);
     for (Expression expression : autoQuarantineExpressions) {
       Boolean expressionResult = expression.getValue(context, Boolean.class);
-      if (expressionResult) {
+      if (expressionResult != null && expressionResult) {
         log.with("exception_report", exceptionReport)
             .with("expression", expression.getExpressionString())
             .warn("Auto-quarantine message rule matched");

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ server:
 
 info:
   app:
-    name: Bad Message Handler
+    name: Exception Manager
     version: 1.0
 
 spring:
@@ -43,3 +43,6 @@ management:
 
 peek:
   timeout: 30000 # milliseconds
+
+general-config:
+  number-of-retries-before-logging: 1

--- a/src/test/java/uk/gov/ons/census/exceptionmanager/endpoint/AdminEndpointIT.java
+++ b/src/test/java/uk/gov/ons/census/exceptionmanager/endpoint/AdminEndpointIT.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.Unirest;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -190,7 +189,7 @@ public class AdminEndpointIT {
 
     assertThat(response.getStatus()).isEqualTo(OK.value());
 
-    List<LinkedHashMap> actualResponse = objectMapper.readValue(response.getBody(), List.class);
+    List<Map> actualResponse = objectMapper.readValue(response.getBody(), List.class);
     assertThat(actualResponse.size()).isEqualTo(0);
 
     // Now send a second exception

--- a/src/test/java/uk/gov/ons/census/exceptionmanager/endpoint/AdminEndpointTest.java
+++ b/src/test/java/uk/gov/ons/census/exceptionmanager/endpoint/AdminEndpointTest.java
@@ -40,7 +40,7 @@ public class AdminEndpointTest {
     AdminEndpoint underTest = new AdminEndpoint(cachingDataStore, 500, null, null);
 
     // When
-    ResponseEntity<Set<String>> actualResponse = underTest.getBadMessages();
+    ResponseEntity<Set<String>> actualResponse = underTest.getBadMessages(-1);
 
     // Then
     assertThat(actualResponse.getBody()).isEqualTo(testSet);
@@ -67,7 +67,7 @@ public class AdminEndpointTest {
     AdminEndpoint underTest = new AdminEndpoint(cachingDataStore, 500, null, null);
 
     // When
-    ResponseEntity<List<BadMessageSummary>> actualResponse = underTest.getBadMessagesSummary();
+    ResponseEntity<List<BadMessageSummary>> actualResponse = underTest.getBadMessagesSummary(-1);
 
     // Then
     verify(cachingDataStore).getSeenMessageHashes();

--- a/src/test/java/uk/gov/ons/census/exceptionmanager/endpoint/AdminEndpointTest.java
+++ b/src/test/java/uk/gov/ons/census/exceptionmanager/endpoint/AdminEndpointTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -207,10 +208,13 @@ public class AdminEndpointTest {
     // When
     AutoQuarantineRule autoQuarantineRule = new AutoQuarantineRule();
     autoQuarantineRule.setExpression("true");
+    autoQuarantineRule.setRuleExpiryDateTime(OffsetDateTime.MAX);
     underTest.addQuarantineRule(autoQuarantineRule);
 
     // Then
-    verify(cachingDataStore).addQuarantineRuleExpression(eq("true"));
+    verify(cachingDataStore)
+        .addQuarantineRuleExpression(
+            eq("true"), eq(false), eq(false), eq(false), any(OffsetDateTime.class));
   }
 
   @Test

--- a/src/test/java/uk/gov/ons/census/exceptionmanager/endpoint/ReportingEndpointIT.java
+++ b/src/test/java/uk/gov/ons/census/exceptionmanager/endpoint/ReportingEndpointIT.java
@@ -5,10 +5,13 @@ import static org.springframework.http.HttpStatus.OK;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.node.TextNode;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.Unirest;
 import com.mashape.unirest.http.exceptions.UnirestException;
+import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -38,6 +41,11 @@ public class ReportingEndpointIT {
       "9af5350f1e61149cd0bb7dfa5efae46f224aaaffed729b220d63e0fe5a8bf4b8";
   private static final ObjectMapper objectMapper = new ObjectMapper();
 
+  static {
+    objectMapper.registerModule(new JavaTimeModule());
+    objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+  }
+
   @Autowired private CachingDataStore cachingDataStore;
   @Autowired private QuarantinedMessageRepository quarantinedMessageRepository;
   @Autowired private AutoQuarantineRuleRepository autoQuarantineRuleRepository;
@@ -61,6 +69,7 @@ public class ReportingEndpointIT {
     assertThat(actualResponse.isSkipIt()).isFalse();
     assertThat(actualResponse.isLogIt()).isTrue();
     assertThat(actualResponse.isPeek()).isFalse();
+    assertThat(actualResponse.isThrowAway()).isFalse();
 
     assertThat(cachingDataStore.getBadMessageReports(TEST_MESSAGE_HASH).size()).isEqualTo(1);
   }
@@ -69,6 +78,8 @@ public class ReportingEndpointIT {
   public void testReportExceptionAutoQuarantine() throws Exception {
     AutoQuarantineRule autoQuarantineRule = new AutoQuarantineRule();
     autoQuarantineRule.setExpression("exceptionMessage.contains('quarantine_me')");
+    autoQuarantineRule.setQuarantine(true);
+    autoQuarantineRule.setRuleExpiryDateTime(OffsetDateTime.now().plusMinutes(1));
 
     ExceptionReport exceptionReport = new ExceptionReport();
     exceptionReport.setMessageHash(TEST_MESSAGE_HASH);
@@ -100,6 +111,49 @@ public class ReportingEndpointIT {
     assertThat(actualResponse.isSkipIt()).isTrue();
     assertThat(actualResponse.isLogIt()).isTrue();
     assertThat(actualResponse.isPeek()).isFalse();
+    assertThat(actualResponse.isThrowAway()).isFalse();
+
+    assertThat(cachingDataStore.getBadMessageReports(TEST_MESSAGE_HASH).size()).isEqualTo(1);
+  }
+
+  @Test
+  public void testReportExceptionAutoQuarantineExpiredRule() throws Exception {
+    AutoQuarantineRule autoQuarantineRule = new AutoQuarantineRule();
+    autoQuarantineRule.setExpression("exceptionMessage.contains('expired_rule')");
+    autoQuarantineRule.setQuarantine(true);
+    autoQuarantineRule.setRuleExpiryDateTime(OffsetDateTime.now().minusSeconds(1));
+
+    ExceptionReport exceptionReport = new ExceptionReport();
+    exceptionReport.setMessageHash(TEST_MESSAGE_HASH);
+    exceptionReport.setService("test service");
+    exceptionReport.setQueue("test queue");
+    exceptionReport.setExceptionClass("test class");
+    exceptionReport.setExceptionMessage("test expired_rule message");
+
+    Map<String, String> headers = new HashMap<>();
+    headers.put("accept", "application/json");
+    headers.put("Content-Type", "application/json");
+    HttpResponse<String> response =
+        Unirest.post(String.format("http://localhost:%d/quarantinerule", port))
+            .headers(headers)
+            .body(objectMapper.writeValueAsString(autoQuarantineRule))
+            .asString();
+
+    assertThat(response.getStatus()).isEqualTo(OK.value());
+
+    response =
+        Unirest.post(String.format("http://localhost:%d/reportexception", port))
+            .headers(headers)
+            .body(objectMapper.writeValueAsString(exceptionReport))
+            .asString();
+
+    assertThat(response.getStatus()).isEqualTo(OK.value());
+
+    Response actualResponse = objectMapper.readValue(response.getBody(), Response.class);
+    assertThat(actualResponse.isSkipIt()).isFalse();
+    assertThat(actualResponse.isLogIt()).isTrue();
+    assertThat(actualResponse.isPeek()).isFalse();
+    assertThat(actualResponse.isThrowAway()).isFalse();
 
     assertThat(cachingDataStore.getBadMessageReports(TEST_MESSAGE_HASH).size()).isEqualTo(1);
   }

--- a/src/test/java/uk/gov/ons/census/exceptionmanager/persistence/CachingDataStoreTest.java
+++ b/src/test/java/uk/gov/ons/census/exceptionmanager/persistence/CachingDataStoreTest.java
@@ -25,7 +25,7 @@ public class CachingDataStoreTest {
     AutoQuarantineRuleRepository autoQuarantineRuleRepository =
         mock(AutoQuarantineRuleRepository.class);
     when(autoQuarantineRuleRepository.findAll()).thenReturn(Collections.emptyList());
-    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository);
+    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository, 0);
     ExceptionReport exceptionReport = new ExceptionReport();
     exceptionReport.setMessageHash("test message hash");
     exceptionReport.setExceptionClass("test class");
@@ -51,7 +51,7 @@ public class CachingDataStoreTest {
     AutoQuarantineRuleRepository autoQuarantineRuleRepository =
         mock(AutoQuarantineRuleRepository.class);
     when(autoQuarantineRuleRepository.findAll()).thenReturn(Collections.emptyList());
-    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository);
+    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository, 0);
     ExceptionReport exceptionReport = new ExceptionReport();
     exceptionReport.setMessageHash("test message hash");
     exceptionReport.setExceptionClass("test class");
@@ -78,7 +78,7 @@ public class CachingDataStoreTest {
     AutoQuarantineRuleRepository autoQuarantineRuleRepository =
         mock(AutoQuarantineRuleRepository.class);
     when(autoQuarantineRuleRepository.findAll()).thenReturn(Collections.emptyList());
-    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository);
+    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository, 0);
     ExceptionReport exceptionReportOne = new ExceptionReport();
     exceptionReportOne.setMessageHash("test message hash");
     exceptionReportOne.setExceptionClass("test class");
@@ -121,7 +121,7 @@ public class CachingDataStoreTest {
     AutoQuarantineRuleRepository autoQuarantineRuleRepository =
         mock(AutoQuarantineRuleRepository.class);
     when(autoQuarantineRuleRepository.findAll()).thenReturn(Collections.emptyList());
-    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository);
+    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository, 0);
     ExceptionReport exceptionReport = new ExceptionReport();
     exceptionReport.setMessageHash("test message hash");
     exceptionReport.setExceptionClass("test class");
@@ -137,11 +137,35 @@ public class CachingDataStoreTest {
   }
 
   @Test
+  public void testShouldWeLogAfterRetries() {
+    AutoQuarantineRuleRepository autoQuarantineRuleRepository =
+        mock(AutoQuarantineRuleRepository.class);
+    when(autoQuarantineRuleRepository.findAll()).thenReturn(Collections.emptyList());
+    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository, 1);
+    ExceptionReport exceptionReport = new ExceptionReport();
+    exceptionReport.setMessageHash("test message hash");
+    exceptionReport.setExceptionClass("test class");
+    exceptionReport.setExceptionMessage("test exception message");
+    exceptionReport.setQueue("test queue");
+    exceptionReport.setService("test service");
+
+    assertThat(underTest.shouldWeLogThisMessage(exceptionReport)).isFalse();
+
+    underTest.updateStats(exceptionReport);
+
+    assertThat(underTest.shouldWeLogThisMessage(exceptionReport)).isTrue();
+
+    underTest.updateStats(exceptionReport);
+
+    assertThat(underTest.shouldWeLogThisMessage(exceptionReport)).isFalse();
+  }
+
+  @Test
   public void testShouldWeSkip() {
     AutoQuarantineRuleRepository autoQuarantineRuleRepository =
         mock(AutoQuarantineRuleRepository.class);
     when(autoQuarantineRuleRepository.findAll()).thenReturn(Collections.emptyList());
-    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository);
+    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository, 0);
     ExceptionReport exceptionReport = new ExceptionReport();
     exceptionReport.setMessageHash("test message hash");
     exceptionReport.setExceptionClass("test class");
@@ -167,7 +191,7 @@ public class CachingDataStoreTest {
     AutoQuarantineRule rule = new AutoQuarantineRule();
     rule.setExpression("exceptionClass == \"test class\" and queue == \"test queue\"");
     when(autoQuarantineRuleRepository.findAll()).thenReturn(Collections.singletonList(rule));
-    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository);
+    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository, 0);
     ExceptionReport exceptionReport = new ExceptionReport();
     exceptionReport.setMessageHash("test message hash");
     exceptionReport.setExceptionClass("test class");
@@ -185,7 +209,7 @@ public class CachingDataStoreTest {
     AutoQuarantineRule rule = new AutoQuarantineRule();
     rule.setExpression("exceptionMessage.contains('message')");
     when(autoQuarantineRuleRepository.findAll()).thenReturn(Collections.singletonList(rule));
-    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository);
+    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository, 0);
     ExceptionReport exceptionReport = new ExceptionReport();
     exceptionReport.setMessageHash("test message hash");
     exceptionReport.setExceptionClass("test class");
@@ -203,7 +227,7 @@ public class CachingDataStoreTest {
     AutoQuarantineRule rule = new AutoQuarantineRule();
     rule.setExpression("exceptionClass == \"noodle\" and queue == \"test queue\"");
     when(autoQuarantineRuleRepository.findAll()).thenReturn(Collections.singletonList(rule));
-    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository);
+    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository, 0);
     ExceptionReport exceptionReport = new ExceptionReport();
     exceptionReport.setMessageHash("test message hash");
     exceptionReport.setExceptionClass("test class");
@@ -219,7 +243,7 @@ public class CachingDataStoreTest {
     AutoQuarantineRuleRepository autoQuarantineRuleRepository =
         mock(AutoQuarantineRuleRepository.class);
     when(autoQuarantineRuleRepository.findAll()).thenReturn(Collections.emptyList());
-    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository);
+    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository, 0);
     ExceptionReport exceptionReport = new ExceptionReport();
     exceptionReport.setMessageHash("test message hash");
     exceptionReport.setExceptionClass("test class");
@@ -243,7 +267,7 @@ public class CachingDataStoreTest {
     AutoQuarantineRuleRepository autoQuarantineRuleRepository =
         mock(AutoQuarantineRuleRepository.class);
     when(autoQuarantineRuleRepository.findAll()).thenReturn(Collections.emptyList());
-    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository);
+    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository, 0);
     ExceptionReport exceptionReportOne = new ExceptionReport();
     exceptionReportOne.setMessageHash("test message hash");
     exceptionReportOne.setExceptionClass("test class");
@@ -274,7 +298,7 @@ public class CachingDataStoreTest {
     AutoQuarantineRuleRepository autoQuarantineRuleRepository =
         mock(AutoQuarantineRuleRepository.class);
     when(autoQuarantineRuleRepository.findAll()).thenReturn(Collections.emptyList());
-    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository);
+    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository, 0);
     Peek peek = new Peek();
     peek.setMessageHash("test message hash");
     peek.setMessagePayload("test message".getBytes());
@@ -289,7 +313,7 @@ public class CachingDataStoreTest {
     AutoQuarantineRuleRepository autoQuarantineRuleRepository =
         mock(AutoQuarantineRuleRepository.class);
     when(autoQuarantineRuleRepository.findAll()).thenReturn(Collections.emptyList());
-    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository);
+    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository, 0);
     SkippedMessage skippedMessage = new SkippedMessage();
     skippedMessage.setMessageHash("test message hash");
     underTest.storeSkippedMessage(skippedMessage);
@@ -305,7 +329,7 @@ public class CachingDataStoreTest {
     AutoQuarantineRuleRepository autoQuarantineRuleRepository =
         mock(AutoQuarantineRuleRepository.class);
     when(autoQuarantineRuleRepository.findAll()).thenReturn(Collections.emptyList());
-    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository);
+    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository, 0);
     SkippedMessage skippedMessageOne = new SkippedMessage();
     skippedMessageOne.setMessageHash("test message hash");
     skippedMessageOne.setQueue("test queue one");
@@ -325,7 +349,7 @@ public class CachingDataStoreTest {
     AutoQuarantineRuleRepository autoQuarantineRuleRepository =
         mock(AutoQuarantineRuleRepository.class);
     when(autoQuarantineRuleRepository.findAll()).thenReturn(Collections.emptyList());
-    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository);
+    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository, 0);
     SkippedMessage skippedMessageOne = new SkippedMessage();
     skippedMessageOne.setMessageHash("test message hash");
     skippedMessageOne.setQueue("test queue one");
@@ -396,7 +420,7 @@ public class CachingDataStoreTest {
     AutoQuarantineRuleRepository autoQuarantineRuleRepository =
         mock(AutoQuarantineRuleRepository.class);
     when(autoQuarantineRuleRepository.findAll()).thenReturn(expectedAutoQuarantineRules);
-    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository);
+    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository, 0);
 
     // When
     List<AutoQuarantineRule> actualQuarantineRules = underTest.getQuarantineRules();
@@ -411,7 +435,7 @@ public class CachingDataStoreTest {
     AutoQuarantineRuleRepository autoQuarantineRuleRepository =
         mock(AutoQuarantineRuleRepository.class);
     when(autoQuarantineRuleRepository.findAll()).thenReturn(expectedAutoQuarantineRules);
-    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository);
+    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository, 0);
     UUID testId = UUID.randomUUID();
 
     // When

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -4,3 +4,6 @@ spring:
 
   rabbitmq:
     port: 35672
+
+general-config:
+  number-of-retries-before-logging: 0


### PR DESCRIPTION
# Motivation and Context
Sometimes, the 3 retries with a 1-second delay is inadequate, and we end up logging and raising an exception with the exception manager. This could be really annoying during the Census, because it will generate a lot of noise. When we've been war-gaming, we've seen that a flood of messages can cause exceptions which resolve themselves, due to locking contention, for example.

# What has changed
Implemented a configurable "minimum number of times to see an exception before we log it".

Implemented a filter on the admin API so that it only returns exceptions which have been seen a certain number of times.

ADDENDUM: I kinda went a bit mad and added more features. Can now "throw away" bad messages (silently skip, don't quarantine, don't log). Can suppress all logging (but not skip/quarantine) if logs are getting noisy. Also, added an expiry date for rules.

# How to test?
Create some exceptions. Only the ones which have been seen more than once should log, and the toolbox bad message wizard should also not see anything which has only been seen once.

# Links
Trello: https://trello.com/c/hP1iPanw