### PR TITLE
reset only the messages that have been resolved

### DIFF
--- a/src/main/java/uk/gov/ons/census/exceptionmanager/endpoint/AdminEndpoint.java
+++ b/src/main/java/uk/gov/ons/census/exceptionmanager/endpoint/AdminEndpoint.java
@@ -154,8 +154,9 @@ public class AdminEndpoint {
 
   @GetMapping(path = "/reset")
   public void reset(
-      @RequestParam(value = "resetOldMessages", required = false) boolean resetOldMessages) {
-    cachingDataStore.reset(resetOldMessages);
+      @RequestParam(value = "lastSeenCutoffSeconds", required = false)
+          Optional<Integer> lastSeenCutoffSeconds) {
+    cachingDataStore.reset(lastSeenCutoffSeconds);
   }
 
   @GetMapping(path = "/quarantinerule")

--- a/src/main/java/uk/gov/ons/census/exceptionmanager/endpoint/AdminEndpoint.java
+++ b/src/main/java/uk/gov/ons/census/exceptionmanager/endpoint/AdminEndpoint.java
@@ -153,8 +153,9 @@ public class AdminEndpoint {
   }
 
   @GetMapping(path = "/reset")
-  public void reset() {
-    cachingDataStore.reset();
+  public void reset(
+      @RequestParam(value = "resetOldMessages", required = false) boolean resetOldMessages) {
+    cachingDataStore.reset(resetOldMessages);
   }
 
   @GetMapping(path = "/quarantinerule")

--- a/src/main/java/uk/gov/ons/census/exceptionmanager/persistence/CachingDataStore.java
+++ b/src/main/java/uk/gov/ons/census/exceptionmanager/persistence/CachingDataStore.java
@@ -208,12 +208,25 @@ public class CachingDataStore {
     return skippedMessages.get(messageHash);
   }
 
-  public void reset() {
-    seenExceptions.clear();
-    messageExceptionReports.clear();
-    messagesToSkip.clear();
-    messagesToPeek.clear();
-    peekedMessages.clear();
+  public void reset(Boolean resetOldMessages) {
+
+    if (resetOldMessages) {
+      for (Entry<ExceptionReport, ExceptionStats> item : seenExceptions.entrySet()) {
+        Long timeDifference =
+            Instant.now().getEpochSecond() - item.getValue().getLastSeen().getEpochSecond();
+
+        if (timeDifference > 300) {
+          seenExceptions.remove(item.getKey());
+          messageExceptionReports.remove(item.getKey().getMessageHash());
+        }
+      }
+    } else {
+      seenExceptions.clear();
+      messageExceptionReports.clear();
+      messagesToSkip.clear();
+      messagesToPeek.clear();
+      peekedMessages.clear();
+    }
   }
 
   public void addQuarantineRuleExpression(

--- a/src/main/java/uk/gov/ons/census/exceptionmanager/persistence/CachingDataStore.java
+++ b/src/main/java/uk/gov/ons/census/exceptionmanager/persistence/CachingDataStore.java
@@ -4,14 +4,8 @@ import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
 import java.time.Instant;
 import java.time.OffsetDateTime;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.expression.EvaluationContext;
@@ -208,14 +202,13 @@ public class CachingDataStore {
     return skippedMessages.get(messageHash);
   }
 
-  public void reset(Boolean resetOldMessages) {
+  public void reset(Optional<Integer> resetOldMessages) {
 
-    if (resetOldMessages) {
+    if (resetOldMessages.isPresent()) {
       for (Entry<ExceptionReport, ExceptionStats> item : seenExceptions.entrySet()) {
-        Long timeDifference =
-            Instant.now().getEpochSecond() - item.getValue().getLastSeen().getEpochSecond();
+        Instant timeCutoff = Instant.now().minusSeconds(resetOldMessages.get());
 
-        if (timeDifference > 300) {
+        if (timeCutoff.isAfter(item.getValue().getLastSeen())) {
           seenExceptions.remove(item.getKey());
           messageExceptionReports.remove(item.getKey().getMessageHash());
         }

--- a/src/test/java/uk/gov/ons/census/exceptionmanager/endpoint/AdminEndpointIT.java
+++ b/src/test/java/uk/gov/ons/census/exceptionmanager/endpoint/AdminEndpointIT.java
@@ -7,11 +7,7 @@ import static uk.gov.ons.census.exceptionmanager.endpoint.ReportingEndpointIT.re
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.Unirest;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -48,7 +44,7 @@ public class AdminEndpointIT {
   public void setUp() {
     quarantinedMessageRepository.deleteAllInBatch();
     rabbitQueueHelper.purgeQueue(TEST_QUEUE_NAME);
-    cachingDataStore.reset(false);
+    cachingDataStore.reset(Optional.empty());
   }
 
   @Test

--- a/src/test/java/uk/gov/ons/census/exceptionmanager/endpoint/AdminEndpointIT.java
+++ b/src/test/java/uk/gov/ons/census/exceptionmanager/endpoint/AdminEndpointIT.java
@@ -48,7 +48,7 @@ public class AdminEndpointIT {
   public void setUp() {
     quarantinedMessageRepository.deleteAllInBatch();
     rabbitQueueHelper.purgeQueue(TEST_QUEUE_NAME);
-    cachingDataStore.reset();
+    cachingDataStore.reset(false);
   }
 
   @Test

--- a/src/test/java/uk/gov/ons/census/exceptionmanager/endpoint/AdminEndpointTest.java
+++ b/src/test/java/uk/gov/ons/census/exceptionmanager/endpoint/AdminEndpointTest.java
@@ -193,10 +193,10 @@ public class AdminEndpointTest {
     AdminEndpoint underTest = new AdminEndpoint(cachingDataStore, 500, null, null);
 
     // When
-    underTest.reset();
+    underTest.reset(false);
 
     // Then
-    verify(cachingDataStore).reset();
+    verify(cachingDataStore).reset(false);
   }
 
   @Test

--- a/src/test/java/uk/gov/ons/census/exceptionmanager/endpoint/AdminEndpointTest.java
+++ b/src/test/java/uk/gov/ons/census/exceptionmanager/endpoint/AdminEndpointTest.java
@@ -193,10 +193,10 @@ public class AdminEndpointTest {
     AdminEndpoint underTest = new AdminEndpoint(cachingDataStore, 500, null, null);
 
     // When
-    underTest.reset(false);
+    underTest.reset(Optional.empty());
 
     // Then
-    verify(cachingDataStore).reset(false);
+    verify(cachingDataStore).reset(Optional.empty());
   }
 
   @Test

--- a/src/test/java/uk/gov/ons/census/exceptionmanager/endpoint/ReportingEndpointIT.java
+++ b/src/test/java/uk/gov/ons/census/exceptionmanager/endpoint/ReportingEndpointIT.java
@@ -55,7 +55,7 @@ public class ReportingEndpointIT {
   @Before
   public void setUp() {
     quarantinedMessageRepository.deleteAllInBatch();
-    cachingDataStore.reset();
+    cachingDataStore.reset(false);
     autoQuarantineRuleRepository.deleteAllInBatch();
   }
 

--- a/src/test/java/uk/gov/ons/census/exceptionmanager/endpoint/ReportingEndpointIT.java
+++ b/src/test/java/uk/gov/ons/census/exceptionmanager/endpoint/ReportingEndpointIT.java
@@ -15,6 +15,7 @@ import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -55,7 +56,7 @@ public class ReportingEndpointIT {
   @Before
   public void setUp() {
     quarantinedMessageRepository.deleteAllInBatch();
-    cachingDataStore.reset(false);
+    cachingDataStore.reset(Optional.empty());
     autoQuarantineRuleRepository.deleteAllInBatch();
   }
 

--- a/src/test/java/uk/gov/ons/census/exceptionmanager/persistence/CachingDataStoreTest.java
+++ b/src/test/java/uk/gov/ons/census/exceptionmanager/persistence/CachingDataStoreTest.java
@@ -408,7 +408,7 @@ public class CachingDataStoreTest {
             .get("test message hash")
             .contains(List.of(skippedMessage)));
 
-    underTest.reset();
+    underTest.reset(false);
 
     assertThat(underTest.getSkippedMessages("test message hash")).contains(skippedMessage);
     assertThat(

--- a/src/test/java/uk/gov/ons/census/exceptionmanager/persistence/CachingDataStoreTest.java
+++ b/src/test/java/uk/gov/ons/census/exceptionmanager/persistence/CachingDataStoreTest.java
@@ -452,7 +452,7 @@ public class CachingDataStoreTest {
     underTest.reset(Optional.of(0));
 
     assertThat(underTest.getBadMessageReports("test message hash")).isEmpty();
-    assertThat(underTest.getBadMessageReports("test message hash")).isEmpty();
+    assertThat(underTest.getBadMessageReports("another test message hash")).isEmpty();
   }
 
   @Test

--- a/src/test/java/uk/gov/ons/census/exceptionmanager/persistence/CachingDataStoreTest.java
+++ b/src/test/java/uk/gov/ons/census/exceptionmanager/persistence/CachingDataStoreTest.java
@@ -408,7 +408,7 @@ public class CachingDataStoreTest {
             .get("test message hash")
             .contains(List.of(skippedMessage)));
 
-    underTest.reset(false);
+    underTest.reset(java.util.Optional.empty());
 
     assertThat(underTest.getSkippedMessages("test message hash")).contains(skippedMessage);
     assertThat(

--- a/src/test/java/uk/gov/ons/census/exceptionmanager/persistence/CachingDataStoreTest.java
+++ b/src/test/java/uk/gov/ons/census/exceptionmanager/persistence/CachingDataStoreTest.java
@@ -449,13 +449,42 @@ public class CachingDataStoreTest {
     exceptionReportTwo.setQueue("test queue");
     exceptionReportTwo.setService("test service");
     underTest.updateStats(exceptionReportTwo);
-    underTest.updateStats(exceptionReportTwo);
-    underTest.updateStats(exceptionReportTwo);
-    underTest.updateStats(exceptionReportTwo);
     underTest.reset(Optional.of(0));
 
     assertThat(underTest.getBadMessageReports("test message hash")).isEmpty();
     assertThat(underTest.getBadMessageReports("test message hash")).isEmpty();
+  }
+
+  @Test
+  public void testResetDoesNotRemoveMessages() {
+    AutoQuarantineRuleRepository autoQuarantineRuleRepository =
+        mock(AutoQuarantineRuleRepository.class);
+    when(autoQuarantineRuleRepository.findAll()).thenReturn(Collections.emptyList());
+    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository, 0);
+
+    ExceptionReport exceptionReportOne = new ExceptionReport();
+    exceptionReportOne.setMessageHash("test message hash");
+    exceptionReportOne.setExceptionClass("test class");
+    exceptionReportOne.setExceptionMessage("test exception message");
+    exceptionReportOne.setQueue("test queue");
+    exceptionReportOne.setService("test service");
+
+    underTest.updateStats(exceptionReportOne);
+    underTest.skipMessage("test message hash");
+
+    ExceptionReport exceptionReportTwo = new ExceptionReport();
+    exceptionReportTwo.setMessageHash("another test message hash");
+    exceptionReportTwo.setExceptionClass("test class");
+    exceptionReportTwo.setExceptionMessage("test exception message");
+    exceptionReportTwo.setQueue("test queue");
+    exceptionReportTwo.setService("test service");
+    underTest.updateStats(exceptionReportTwo);
+
+    underTest.reset(Optional.of(1000));
+
+    assertThat(underTest.getBadMessageReports("test message hash")).isNotEmpty();
+
+    assertThat(underTest.getBadMessageReports("another test message hash")).isNotEmpty();
   }
 
   @Test

--- a/src/test/java/uk/gov/ons/census/exceptionmanager/persistence/CachingDataStoreTest.java
+++ b/src/test/java/uk/gov/ons/census/exceptionmanager/persistence/CachingDataStoreTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
@@ -423,6 +424,38 @@ public class CachingDataStoreTest {
     assertThat(underTest.getBadMessageReports("test message hash")).isEmpty();
     assertThat(underTest.getAllSkippedMessages()).isNotEmpty();
     assertThat(underTest.getAllSkippedMessages()).isNotEmpty();
+  }
+
+  @Test
+  public void testResetUnseenMessages() {
+    AutoQuarantineRuleRepository autoQuarantineRuleRepository =
+        mock(AutoQuarantineRuleRepository.class);
+    when(autoQuarantineRuleRepository.findAll()).thenReturn(Collections.emptyList());
+    CachingDataStore underTest = new CachingDataStore(autoQuarantineRuleRepository, 0);
+
+    ExceptionReport exceptionReportOne = new ExceptionReport();
+    exceptionReportOne.setMessageHash("test message hash");
+    exceptionReportOne.setExceptionClass("test class");
+    exceptionReportOne.setExceptionMessage("test exception message");
+    exceptionReportOne.setQueue("test queue");
+    exceptionReportOne.setService("test service");
+
+    underTest.updateStats(exceptionReportOne);
+
+    ExceptionReport exceptionReportTwo = new ExceptionReport();
+    exceptionReportTwo.setMessageHash("another test message hash");
+    exceptionReportTwo.setExceptionClass("test class");
+    exceptionReportTwo.setExceptionMessage("test exception message");
+    exceptionReportTwo.setQueue("test queue");
+    exceptionReportTwo.setService("test service");
+    underTest.updateStats(exceptionReportTwo);
+    underTest.updateStats(exceptionReportTwo);
+    underTest.updateStats(exceptionReportTwo);
+    underTest.updateStats(exceptionReportTwo);
+    underTest.reset(Optional.of(0));
+
+    assertThat(underTest.getBadMessageReports("test message hash")).isEmpty();
+    assertThat(underTest.getBadMessageReports("test message hash")).isEmpty();
   }
 
   @Test


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Instead of resetting all of the bad message cache, we want to have an option to be able to remove only the bad messages that have been resolved and not seen in the last 5 minutes.
# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Added optional parameter to reset method to be able to only reset the bad messages that have been resolved.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- run `mvn clean install`
- Run with toolbox PR
- Create some bad messages and "resolve" them (I did this by purging the DelayedRedeliveryQueue)
- Once purged, create some more bad messages. These ones should be repeatedly seen by the exception manager.
- Wait 5 minutes and in the message wizard, use the `Reset resolved bad messages` to remove them from the cache. The only bad messages left on the bad message wizard should be the ones after the purge.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/48p2DeUH/)